### PR TITLE
Auth Controller 테스트 코드 생성

### DIFF
--- a/src/routes/auth/auth.controller.ts
+++ b/src/routes/auth/auth.controller.ts
@@ -7,15 +7,22 @@ import { UserService } from "@/routes/user/user.service";
 export class AuthController {
   constructor(private userService: UserService, private authService: AuthService) {}
 
-  async signin() {
+  // localGuard를 통해 검증된 User 정보를 가져옴
+  // 해당 User 정보를 통해 access token과 refresh token을 발급
+  // 발급된 token을 response header에 담아서 전송
+  async signin(SigninDTO: any, user: any, res: any) {
     return ["string", "string"];
   }
 
-  async signout() {
+  // AuthGuard를 통해 검증된 User 정보를 가져옴
+  // response header에 담겨있는 token을 제거
+  async signout(user: any, res: any) {
     return;
   }
 
-  async refresh() {
-    return ["string", "string"];
+  // AuthGuard를 통해 검증된 User 정보를 가져옴
+  // 검증된 User 정보를 통해 access token 재발급
+  async refresh(user: any, res: any) {
+    return;
   }
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,6 @@
+const enum EJwtTokenType {
+  ACCESS = "access",
+  REFRESH = "refresh",
+}
+
+export { EJwtTokenType };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from "./user";
+export * from "./auth";

--- a/test/routes/auth/auth.controller.spec.ts
+++ b/test/routes/auth/auth.controller.spec.ts
@@ -1,0 +1,113 @@
+import { TestingModule } from "@nestjs/testing";
+
+import { RESPONSE_MOCK } from "test/utils/mock";
+import createTestingModule from "test/utils/mongo/createTestModule";
+import {
+  TOKEN_STUB,
+  TOKEN_USER_STUB,
+  USER_ID_PASSWORD_STUB,
+  USER_STUB_NON_PASSWORD,
+} from "test/utils/stub";
+
+import { AuthController } from "@/routes/auth/auth.controller";
+import { AuthService } from "@/routes/auth/auth.service";
+import { UserService } from "@/routes/user/user.service";
+import { EJwtTokenType } from "@/types";
+
+jest.mock("@/routes/auth/auth.service");
+jest.mock("@/routes/user/user.service");
+
+describe("AuthController", () => {
+  let controller: AuthController;
+  let authService: AuthService;
+  let userService: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await createTestingModule({
+      controllers: [AuthController],
+      providers: [AuthService, UserService],
+    });
+
+    controller = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+    userService = module.get<UserService>(UserService);
+  });
+
+  describe("로그인", () => {
+    let userServiceGetByIdSpy: jest.SpyInstance;
+    let authServiceSigninSpy: jest.SpyInstance;
+    let authServiceRegisterTokenInCookieSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      userServiceGetByIdSpy = jest.spyOn(userService, "getById");
+      authServiceSigninSpy = jest.spyOn(authService, "signin");
+      authServiceRegisterTokenInCookieSpy = jest.spyOn(authService, "registerTokenInCookie");
+    });
+
+    it("성공", async () => {
+      userServiceGetByIdSpy.mockResolvedValueOnce(USER_STUB_NON_PASSWORD);
+      authServiceSigninSpy.mockResolvedValueOnce([TOKEN_STUB, TOKEN_STUB]);
+
+      const result = await controller.signin(USER_ID_PASSWORD_STUB, TOKEN_USER_STUB, RESPONSE_MOCK);
+
+      expect(userServiceGetByIdSpy).toBeCalledWith(TOKEN_USER_STUB._id);
+      expect(authServiceSigninSpy).toBeCalledWith(USER_ID_PASSWORD_STUB);
+      expect(authServiceRegisterTokenInCookieSpy).toBeCalledTimes(2);
+      expect(authServiceRegisterTokenInCookieSpy).toBeCalledWith({
+        type: EJwtTokenType.ACCESS,
+        token: TOKEN_STUB,
+        RESPONSE_MOCK,
+      });
+      expect(authServiceRegisterTokenInCookieSpy).toBeCalledWith({
+        type: EJwtTokenType.REFRESH,
+        token: TOKEN_STUB,
+        RESPONSE_MOCK,
+      });
+      expect(result).toEqual(USER_STUB_NON_PASSWORD);
+    });
+  });
+
+  describe("로그아웃", () => {
+    let userServiceUpdateRefreshTokenSpy: jest.SpyInstance;
+    let authServiceClearCookieSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      userServiceUpdateRefreshTokenSpy = jest.spyOn(userService, "updateRefreshToken");
+      authServiceClearCookieSpy = jest.spyOn(authService, "clearCookie");
+    });
+
+    it("성공", async () => {
+      await controller.signout(TOKEN_USER_STUB, RESPONSE_MOCK);
+
+      expect(userServiceUpdateRefreshTokenSpy).toBeCalledTimes(1);
+      expect(userServiceUpdateRefreshTokenSpy).toBeCalledWith(TOKEN_USER_STUB._id, null);
+      expect(authServiceClearCookieSpy).toBeCalledTimes(1);
+      expect(authServiceClearCookieSpy).toBeCalledWith(RESPONSE_MOCK);
+    });
+  });
+
+  describe("토큰 재발급", () => {
+    let authServiceSigninSpy: jest.SpyInstance;
+    let authServiceRegisterTokenInCookieSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      authServiceSigninSpy = jest.spyOn(authService, "signin");
+      authServiceRegisterTokenInCookieSpy = jest.spyOn(authService, "registerTokenInCookie");
+    });
+
+    it("성공", async () => {
+      authServiceSigninSpy.mockReturnValueOnce([TOKEN_STUB, TOKEN_STUB]);
+
+      await controller.refresh(TOKEN_USER_STUB, RESPONSE_MOCK);
+
+      expect(authServiceSigninSpy).toBeCalledTimes(1);
+      expect(authServiceSigninSpy).toBeCalledWith([TOKEN_STUB, TOKEN_STUB]);
+      expect(authServiceRegisterTokenInCookieSpy).toBeCalledTimes(1);
+      expect(authServiceRegisterTokenInCookieSpy).toBeCalledWith({
+        type: EJwtTokenType.ACCESS,
+        token: TOKEN_STUB,
+        RESPONSE_MOCK,
+      });
+    });
+  });
+});

--- a/test/utils/stub/user.ts
+++ b/test/utils/stub/user.ts
@@ -1,7 +1,16 @@
-const USER_STUB_NON_PASSWORD = {
+const TOKEN_USER_STUB = {
   _id: "id",
-  username: "test",
+};
+
+const USER_ID_PASSWORD_STUB = {
   userId: "test",
+  password: "test",
+};
+
+const USER_STUB_NON_PASSWORD = {
+  ...TOKEN_USER_STUB,
+  userId: "test",
+  username: "test",
   refreshToken: null,
   nid: 1,
 };
@@ -12,9 +21,14 @@ const USER_STUB = {
 };
 
 const USER_INPUT_STUB = {
+  ...USER_ID_PASSWORD_STUB,
   username: "test",
-  userId: "test",
-  password: "test",
 };
 
-export { USER_STUB_NON_PASSWORD, USER_STUB, USER_INPUT_STUB };
+export {
+  TOKEN_USER_STUB,
+  USER_ID_PASSWORD_STUB,
+  USER_STUB_NON_PASSWORD,
+  USER_STUB,
+  USER_INPUT_STUB,
+};


### PR DESCRIPTION
- #7 

## ✨ **구현 기능 명세**
- Auth Controller 테스트 코드를 생성합니다.
- 유닛 테스트로 진행하며 UserService, AuthService를 Mocking해서 테스트를 진행합니다.
- TDD로 진행하기 때문에 현재는 실패하는 테스트 코드입니다.
