### PR TITLE
Auth Service 비즈니스 로직 생성

### DIFF
--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -1,10 +1,10 @@
+import { CookieOptions, Response } from "express";
+
 import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { JwtService, JwtSignOptions } from "@nestjs/jwt";
 
-import * as bcrypt from "bcrypt";
-
 import { AuthConstantProvider } from "@/common/providers/auth-constant.provider";
-import { TTokenUser } from "@/types";
+import { EJwtTokenType, IRegisterTokenInCookieArgs, TTokenUser } from "@/types";
 import { USER_ERROR } from "@/utils/constants";
 
 @Injectable()
@@ -46,13 +46,27 @@ export class AuthService {
     return this.jwtService.sign({ id: _id }, options);
   }
 
-  // 토큰을 쿠키에 등록
-  registerTokenInCookie() {
-    return;
+  // response header에 access token과 refresh token을 등록
+  registerTokenInCookie({ type, token, res }: IRegisterTokenInCookieArgs) {
+    const { ACCESS_HEADER, REFRESH_HEADER, COOKIE_MAX_AGE } = this.authConstantProvider;
+
+    const isRefresh = type === EJwtTokenType.REFRESH;
+    const tokenName = isRefresh ? REFRESH_HEADER : ACCESS_HEADER;
+
+    const cookieOptions: CookieOptions = {
+      httpOnly: true,
+      maxAge: Number(COOKIE_MAX_AGE),
+      secure: true,
+    };
+
+    res.cookie(tokenName, token, cookieOptions);
   }
 
   // response header에서 access token과 refresh token을 삭제
-  clearCookie() {
-    return;
+  clearCookie(res: Response) {
+    const { ACCESS_HEADER, REFRESH_HEADER } = this.authConstantProvider;
+
+    res.clearCookie(ACCESS_HEADER);
+    res.clearCookie(REFRESH_HEADER);
   }
 }

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -1,8 +1,11 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { JwtService, JwtSignOptions } from "@nestjs/jwt";
+
+import * as bcrypt from "bcrypt";
 
 import { AuthConstantProvider } from "@/common/providers/auth-constant.provider";
 import { TTokenUser } from "@/types";
+import { USER_ERROR } from "@/utils/constants";
 
 @Injectable()
 export class AuthService {
@@ -26,16 +29,16 @@ export class AuthService {
 
   // refresh token 유효성 검사
   // 서버에 저장된 유저 토큰이 유효한 토큰인지 확인
-  async verifyRefreshToken(user: any, refreshToken: string) {
-    return true;
-  }
+  async verifyRefreshToken(refreshToken: string) {
+    try {
+      const isVerify = await this.jwtService.verify(refreshToken);
 
-  // 로그인 요청시 입력한 아이디와 비밀번호가 유저 정보와 일치하는지 확인
-  // 확인됐다면 유저 정보를 반환
-  // 유저 패스워드와 입력받은 패스워드를 비교
-  // 함수 단위를 작게 가져가기위해 내부에서 user 정보를 가져오지 않음
-  async comparePassword(uPassword: string, password: string) {
-    return true;
+      if (!Boolean(isVerify)) throw new UnauthorizedException();
+
+      return true;
+    } catch (e) {
+      throw new UnauthorizedException(USER_ERROR.UNAUTHORIZED);
+    }
   }
 
   // 입력받은 데이터를 통해 토큰을 발급

--- a/src/routes/auth/auth.service.ts
+++ b/src/routes/auth/auth.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from "@nestjs/common";
-import { JwtService } from "@nestjs/jwt";
-
-import { USER_STUB } from "test/utils/stub";
+import { JwtService, JwtSignOptions } from "@nestjs/jwt";
 
 import { AuthConstantProvider } from "@/common/providers/auth-constant.provider";
+import { TTokenUser } from "@/types";
 
 @Injectable()
 export class AuthService {
@@ -13,8 +12,16 @@ export class AuthService {
   ) {}
 
   // 로그인시 access token과 refresh token을 발급
-  async signin(SignInDTO: any) {
-    return ["string", "string"];
+  async signin(user: TTokenUser) {
+    const { ACCESS_EXPIRES, REFRESH_EXPIRES } = this.authConstantProvider;
+
+    const accessOptions: JwtSignOptions = { expiresIn: ACCESS_EXPIRES };
+    const refreshOptions: JwtSignOptions = { expiresIn: REFRESH_EXPIRES };
+
+    const accessToken = this.signature(user._id, accessOptions);
+    const refreshToken = this.signature(user._id, refreshOptions);
+
+    return [accessToken, refreshToken];
   }
 
   // refresh token 유효성 검사
@@ -31,18 +38,18 @@ export class AuthService {
     return true;
   }
 
-  // response header에서 access token과 refresh token을 삭제
-  async clearCookie() {
-    return;
-  }
-
   // 입력받은 데이터를 통해 토큰을 발급
-  signature() {
-    return "";
+  signature(_id: string, options: JwtSignOptions) {
+    return this.jwtService.sign({ id: _id }, options);
   }
 
   // 토큰을 쿠키에 등록
   registerTokenInCookie() {
+    return;
+  }
+
+  // response header에서 access token과 refresh token을 삭제
+  clearCookie() {
     return;
   }
 }

--- a/src/routes/user/user.schema.ts
+++ b/src/routes/user/user.schema.ts
@@ -1,6 +1,6 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 
-import { Model } from "mongoose";
+import { Document, Model } from "mongoose";
 
 import { BaseSchema } from "@/common/schema/base.schema";
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,6 +1,14 @@
+import { Response } from "express";
+
 const enum EJwtTokenType {
   ACCESS = "access",
   REFRESH = "refresh",
 }
 
-export { EJwtTokenType };
+interface IRegisterTokenInCookieArgs {
+  type: EJwtTokenType;
+  token: string;
+  res: Response;
+}
+
+export { EJwtTokenType, IRegisterTokenInCookieArgs };

--- a/test/routes/auth/auth.service.spec.ts
+++ b/test/routes/auth/auth.service.spec.ts
@@ -1,9 +1,8 @@
 import { JwtModule, JwtService } from "@nestjs/jwt";
 import { TestingModule } from "@nestjs/testing";
 
-import * as bcrypt from "bcrypt";
 import createTestingModule from "test/utils/mongo/createTestModule";
-import { TOKEN_STUB, TOKEN_USER_STUB, USER_STUB, USER_STUB_NON_PASSWORD } from "test/utils/stub";
+import { TOKEN_STUB, TOKEN_USER_STUB, USER_STUB } from "test/utils/stub";
 
 import { AuthConstantProvider } from "@/common/providers/auth-constant.provider";
 import { AuthService } from "@/routes/auth/auth.service";
@@ -11,7 +10,6 @@ import { USER_ERROR } from "@/utils/constants";
 
 jest.mock("@/routes/user/user.service");
 jest.mock("@/common/providers/auth-constant.provider");
-jest.mock("bcrypt");
 
 describe("AuthService", () => {
   let authService: AuthService;
@@ -64,38 +62,6 @@ describe("AuthService", () => {
     });
   });
 
-  describe("입력한 아이디와 비밀번호가 유저 정보와 일치하는지 확인", () => {
-    let bcryptCompareSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      bcryptCompareSpy = jest.spyOn(bcrypt, "compare");
-    });
-
-    it("성공", async () => {
-      bcryptCompareSpy.mockReturnValueOnce(true);
-
-      const result = await authService.comparePassword(USER_STUB.password, USER_STUB.password);
-
-      expect(result).toEqual(USER_STUB_NON_PASSWORD);
-    });
-
-    describe("실패", () => {
-      // 실패 조건?
-      // 1. 유저 정보가 없는 경우
-      // 2. 비밀번호가 일치하지 않는 경우
-      it("비밀번호가 일치하지 않는 경우", async () => {
-        bcryptCompareSpy.mockReturnValueOnce(false);
-
-        try {
-          await authService.comparePassword(USER_STUB.password, USER_STUB.password);
-        } catch (e) {
-          expect(e.status).toBe(400);
-          expect(e.message).toBe(USER_ERROR.BAD_REQUEST);
-        }
-      });
-    });
-  });
-
   describe("refresh token 유효성 검사", () => {
     let jwtServiceVerifySpy: jest.SpyInstance;
 
@@ -106,21 +72,20 @@ describe("AuthService", () => {
     it("성공", async () => {
       jwtServiceVerifySpy.mockReturnValueOnce(true);
 
-      const result = await authService.verifyRefreshToken(USER_STUB, USER_STUB.refreshToken);
+      const result = await authService.verifyRefreshToken(USER_STUB.refreshToken);
 
       expect(jwtServiceVerifySpy).toHaveBeenCalledTimes(1);
-      expect(jwtServiceVerifySpy).toHaveBeenCalledWith({
-        _id: USER_STUB_NON_PASSWORD._id,
-      });
+      expect(jwtServiceVerifySpy).toHaveBeenCalledWith(USER_STUB.refreshToken);
       expect(result).toBe(true);
     });
 
     describe("실패", () => {
       it("유저 정보에 refresh token이 없는 경우", async () => {
         try {
-          await authService.verifyRefreshToken(USER_STUB, null);
+          await authService.verifyRefreshToken(null);
         } catch (e) {
           expect(e.status).toBe(401);
+          expect(jwtServiceVerifySpy).toHaveBeenCalledTimes(1);
           expect(e.message).toBe(USER_ERROR.UNAUTHORIZED);
         }
       });
@@ -129,9 +94,10 @@ describe("AuthService", () => {
         jwtServiceVerifySpy.mockRejectedValueOnce(new Error());
 
         try {
-          await authService.verifyRefreshToken(USER_STUB, USER_STUB.refreshToken);
+          await authService.verifyRefreshToken(USER_STUB.refreshToken);
         } catch (e) {
           expect(e.status).toBe(401);
+          expect(jwtServiceVerifySpy).toHaveBeenCalledTimes(1);
           expect(e.message).toBe(USER_ERROR.UNAUTHORIZED);
         }
       });

--- a/test/routes/auth/auth.service.spec.ts
+++ b/test/routes/auth/auth.service.spec.ts
@@ -3,13 +3,12 @@ import { TestingModule } from "@nestjs/testing";
 
 import * as bcrypt from "bcrypt";
 import createTestingModule from "test/utils/mongo/createTestModule";
-import { TOKEN_STUB, USER_STUB, USER_STUB_NON_PASSWORD } from "test/utils/stub";
+import { TOKEN_STUB, TOKEN_USER_STUB, USER_STUB, USER_STUB_NON_PASSWORD } from "test/utils/stub";
 
 import { AuthConstantProvider } from "@/common/providers/auth-constant.provider";
 import { AuthService } from "@/routes/auth/auth.service";
 import { USER_ERROR } from "@/utils/constants";
 
-jest.mock("@/routes/auth/auth.service");
 jest.mock("@/routes/user/user.service");
 jest.mock("@/common/providers/auth-constant.provider");
 jest.mock("bcrypt");
@@ -52,24 +51,15 @@ describe("AuthService", () => {
   });
 
   describe("로그인", () => {
-    let authServiceSignatureSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      authServiceSignatureSpy = jest.spyOn(authService, "signature");
-    });
-
     // 로그인시 access token과 refresh token을 발급
     // response header를 mock으로 만들어서 테스트
     it("성공", async () => {
-      authServiceSignatureSpy.mockReturnValueOnce(TOKEN_STUB);
+      authService.signature = jest.fn().mockReturnValue(TOKEN_STUB);
 
-      const USER_INPUT = {
-        userId: USER_STUB.userId,
-        password: USER_STUB.password,
-      };
+      const result = await authService.signin(TOKEN_USER_STUB);
 
-      const result = await authService.signin(USER_INPUT);
-
+      expect(authService.signature).toHaveBeenCalledTimes(2);
+      expect(authService.signature).toReturnWith(TOKEN_STUB);
       expect(result).toEqual([TOKEN_STUB, TOKEN_STUB]);
     });
   });

--- a/test/utils/mock/auth.ts
+++ b/test/utils/mock/auth.ts
@@ -1,6 +1,8 @@
+import { Response } from "express";
+
 const RESPONSE_MOCK = {
   cookie: jest.fn(),
   clearCookie: jest.fn(),
-};
+} as unknown as Response;
 
 export { RESPONSE_MOCK };


### PR DESCRIPTION
- #7

## ✨ **구현 기능 명세**
- Auth Service 비즈니스 로직을 생성합니다.
- 로그인, 토큰 유효성 검사, 유저 정보 검사 등 인증과 관련된 로직을 생성합니다.
- 함수가 함수 이름에 따라 하나의 역할만 할 수 있도록 조정합니다.
   - 기존 auth service 내부에서 user 정보를 검색해 반환하는 로직을 제거합니다.

## 🌄 **스크린샷**
<img width="825" alt="image" src="https://github.com/seoko97/SEOKO-server/assets/60173534/9e40f674-7d34-4f2f-9fee-344da69c62a9">
