### PR TITLE
Tag Service 테스트 및 비즈니스 로직 생성

### DIFF
--- a/src/routes/tag/tag.module.ts
+++ b/src/routes/tag/tag.module.ts
@@ -1,9 +1,16 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 
+import { SequenceModule } from "@/common/sequence/sequence.module";
+import { TagController } from "@/routes/tag/tag.controller";
+import { TagRepository } from "@/routes/tag/tag.repository";
 import { Tag, TagSchema } from "@/routes/tag/tag.schema";
+import { TagService } from "@/routes/tag/tag.service";
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: Tag.name, schema: TagSchema }])],
+  imports: [MongooseModule.forFeature([{ name: Tag.name, schema: TagSchema }]), SequenceModule],
+  controllers: [TagController],
+  providers: [TagService, TagRepository],
+  exports: [TagService, TagRepository],
 })
 export class TagModule {}

--- a/src/routes/tag/tag.repository.ts
+++ b/src/routes/tag/tag.repository.ts
@@ -1,0 +1,62 @@
+import { Inject, Injectable } from "@nestjs/common";
+
+import { SequenceRepository } from "@/common/sequence/sequence.repository";
+import { Tag, TagDocument, TagModel } from "@/routes/tag/tag.schema";
+import { GET_TAGS_OPTIONS } from "@/utils/constants/tag";
+
+@Injectable()
+export class TagRepository {
+  constructor(
+    @Inject(Tag.name) private readonly tagModel: TagModel,
+    private readonly sequenceRepository: SequenceRepository,
+  ) {}
+
+  async addPostIdInTags(tags: TagDocument[], postId: string) {
+    return await this.tagModel.updateMany(
+      { _id: { $in: tags.map((tag) => tag._id) } },
+      { $addToSet: { posts: postId } },
+    );
+  }
+
+  async pullPostIdInTagNames(tagNames: string[], postId: string) {
+    await this.tagModel
+      .updateMany({ name: { $in: tagNames } }, { $pull: { posts: postId } })
+      .exec();
+
+    await this.deleteTagsByEmptyPosts();
+  }
+
+  async pullPostIdByPostId(postId: string) {
+    await this.tagModel.updateMany({ posts: { $in: postId } }, { $pull: { posts: postId } });
+
+    await this.deleteTagsByEmptyPosts();
+  }
+
+  async deleteTagsByEmptyPosts() {
+    await this.tagModel.deleteMany({ posts: { $size: 0 } });
+  }
+
+  async findOrCreate(name: string) {
+    const tag = await this.tagModel.findOne({ name });
+
+    if (tag) return tag;
+
+    const nid = await this.sequenceRepository.getNextSequence("tag");
+
+    return await this.tagModel.create({ name, nid });
+  }
+
+  async getByName(name: string) {
+    const tag = await this.tagModel.findOne({ name }).populate("posts");
+
+    return tag[0];
+  }
+
+  async getAll() {
+    return await this.tagModel.aggregate<TagDocument>(GET_TAGS_OPTIONS).exec();
+  }
+
+  async getAllByTagNames(tagNames: string[]) {
+    return await this.tagModel.find({ name: { $in: tagNames } });
+  }
+}

--- a/src/routes/tag/tag.schema.ts
+++ b/src/routes/tag/tag.schema.ts
@@ -12,7 +12,7 @@ export type TagModel = Model<TagDocument>;
 @Schema()
 export class Tag extends BaseSchema {
   @IsString()
-  @Prop({ required: true })
+  @Prop({ required: true, unique: true })
   name!: string;
 
   @Prop({

--- a/src/routes/tag/tag.service.ts
+++ b/src/routes/tag/tag.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@nestjs/common";
+
+import { TagRepository } from "@/routes/tag/tag.repository";
+
+@Injectable()
+export class TagService {
+  constructor(private readonly tagRepository: TagRepository) {}
+
+  async getAll() {
+    return this.tagRepository.getAll();
+  }
+
+  async getByName(name: string) {
+    return this.tagRepository.getByName(name);
+  }
+
+  async pushPostIdInTagNames(tagNames: string[], postId: string) {
+    const tags = await Promise.all(
+      tagNames.map((tagName) => this.tagRepository.findOrCreate(tagName)),
+    );
+
+    await this.tagRepository.addPostIdInTags(tags, postId);
+
+    return tags;
+  }
+
+  async pullPostIdInTagNames(tagNames: string[], postId: string) {
+    await this.tagRepository.pullPostIdInTagNames(tagNames, postId);
+
+    return this.tagRepository.getAllByTagNames(tagNames);
+  }
+
+  async pullPostIdByPostId(postId: string) {
+    await this.tagRepository.pullPostIdByPostId(postId);
+  }
+}

--- a/src/utils/constants/tag.ts
+++ b/src/utils/constants/tag.ts
@@ -1,0 +1,33 @@
+import { PipelineStage } from "mongoose";
+
+const TAG_ERROR = {
+  NOT_FOUND: "존재하지 않는 태그입니다.",
+  ALREADY_EXIST: "이미 존재하는 태그입니다.",
+};
+
+const GET_TAGS_OPTIONS: PipelineStage[] = [
+  {
+    $lookup: {
+      from: "posts",
+      localField: "posts",
+      foreignField: "_id",
+      as: "posts",
+    },
+  },
+  {
+    $project: {
+      _id: 1,
+      name: 1,
+      createdAt: 1,
+      updatedAt: 1,
+      postCount: { $size: "$posts" },
+    },
+  },
+  {
+    $sort: {
+      postCount: -1,
+    },
+  },
+];
+
+export { TAG_ERROR, GET_TAGS_OPTIONS };

--- a/test/routes/series/series.controller.spec.ts
+++ b/test/routes/series/series.controller.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 
-import { SERIES_STUB } from "test/utils/stub/series";
+import { SERIES_STUB } from "test/utils/stub";
 
 import { SeriesController } from "@/routes/series/series.controller";
 import { SeriesService } from "@/routes/series/series.service";

--- a/test/routes/tag/tag.service.spec.ts
+++ b/test/routes/tag/tag.service.spec.ts
@@ -1,0 +1,121 @@
+import { Test, TestingModule } from "@nestjs/testing";
+
+import { TAG_STUB } from "test/utils/stub";
+
+import { TagRepository } from "@/routes/tag/tag.repository";
+import { TagService } from "@/routes/tag/tag.service";
+
+jest.mock("@/routes/tag/tag.repository");
+
+describe("TagService", () => {
+  let service: TagService;
+  let repository: TagRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TagService, TagRepository],
+    }).compile();
+
+    service = module.get<TagService>(TagService);
+    repository = module.get<TagRepository>(TagRepository);
+
+    jest.clearAllMocks();
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  describe("태그 조회", () => {
+    it("태그 전체 조회", async () => {
+      const repositoryGetAllSpy: jest.SpyInstance = jest.spyOn(repository, "getAll");
+      repositoryGetAllSpy.mockResolvedValueOnce([TAG_STUB]);
+
+      const tags = await service.getAll();
+
+      expect(tags).toEqual([TAG_STUB]);
+      expect(repositoryGetAllSpy).toHaveBeenCalled();
+      expect(repositoryGetAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("태그 이름으로 조회", async () => {
+      const repositoryGetByNameSpy: jest.SpyInstance = jest.spyOn(repository, "getByName");
+      repositoryGetByNameSpy.mockResolvedValueOnce(TAG_STUB);
+
+      const tag = await service.getByName(TAG_STUB.name);
+
+      expect(tag).toEqual(TAG_STUB);
+      expect(repositoryGetByNameSpy).toHaveBeenCalled();
+      expect(repositoryGetByNameSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryGetByNameSpy).toHaveBeenCalledWith(TAG_STUB.name);
+    });
+  });
+
+  describe("태그에 게시글 추가", () => {
+    it("성공", async () => {
+      const repositoryFindOrCreateSpy: jest.SpyInstance = jest.spyOn(repository, "findOrCreate");
+      const repositoryAddPostIdInTagsSpy: jest.SpyInstance = jest.spyOn(
+        repository,
+        "addPostIdInTags",
+      );
+      repositoryFindOrCreateSpy.mockResolvedValueOnce(TAG_STUB);
+      repositoryAddPostIdInTagsSpy.mockResolvedValueOnce(TAG_STUB);
+
+      const tags = await service.pushPostIdInTagNames([TAG_STUB.name], TAG_STUB.posts[0]._id);
+
+      expect(tags).toEqual([TAG_STUB]);
+
+      expect(repositoryFindOrCreateSpy).toHaveBeenCalled();
+      expect(repositoryFindOrCreateSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryFindOrCreateSpy).toHaveBeenCalledWith(TAG_STUB.name);
+
+      expect(repositoryAddPostIdInTagsSpy).toHaveBeenCalled();
+      expect(repositoryAddPostIdInTagsSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryAddPostIdInTagsSpy).toHaveBeenCalledWith([TAG_STUB], TAG_STUB.posts[0]._id);
+    });
+  });
+
+  describe("태그에 게시글 삭제", () => {
+    it("태그 이름 배열을 받아 해당 이름과 일치하는 태그를 찾아 게시글 아이디를 삭제한다", async () => {
+      const repositoryPullPostIdInTagNamesSpy: jest.SpyInstance = jest.spyOn(
+        repository,
+        "pullPostIdInTagNames",
+      );
+      const repositoryGetAllByTagNamesSpy: jest.SpyInstance = jest.spyOn(
+        repository,
+        "getAllByTagNames",
+      );
+      repositoryPullPostIdInTagNamesSpy.mockResolvedValueOnce(true);
+      repositoryGetAllByTagNamesSpy.mockResolvedValueOnce([TAG_STUB]);
+
+      const tags = await service.pullPostIdInTagNames([TAG_STUB.name], TAG_STUB.posts[0]._id);
+
+      expect(tags).toEqual([TAG_STUB]);
+
+      expect(repositoryPullPostIdInTagNamesSpy).toHaveBeenCalled();
+      expect(repositoryPullPostIdInTagNamesSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryPullPostIdInTagNamesSpy).toHaveBeenCalledWith(
+        [TAG_STUB.name],
+        TAG_STUB.posts[0]._id,
+      );
+
+      expect(repositoryGetAllByTagNamesSpy).toHaveBeenCalled();
+      expect(repositoryGetAllByTagNamesSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryGetAllByTagNamesSpy).toHaveBeenCalledWith([TAG_STUB.name]);
+    });
+
+    it("게시글 아이디를 받아 해당 게시글을 가지고 있는 태그를 찾아 게시글 아이디를 삭제한다", async () => {
+      const repositoryPullPostIdByPostIdSpy: jest.SpyInstance = jest.spyOn(
+        repository,
+        "pullPostIdByPostId",
+      );
+      repositoryPullPostIdByPostIdSpy.mockResolvedValueOnce(undefined);
+
+      await service.pullPostIdByPostId(TAG_STUB.posts[0]._id);
+
+      expect(repositoryPullPostIdByPostIdSpy).toHaveBeenCalled();
+      expect(repositoryPullPostIdByPostIdSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryPullPostIdByPostIdSpy).toHaveBeenCalledWith(TAG_STUB.posts[0]._id);
+    });
+  });
+});

--- a/test/utils/stub/index.ts
+++ b/test/utils/stub/index.ts
@@ -1,2 +1,4 @@
 export * from "./user";
 export * from "./auth";
+export * from "./tag";
+export * from "./series";

--- a/test/utils/stub/tag.ts
+++ b/test/utils/stub/tag.ts
@@ -1,0 +1,17 @@
+const TAG_INPUT_STUB = {
+  name: "태그",
+};
+
+const TAG_STUB = {
+  ...TAG_INPUT_STUB,
+  _id: "_id",
+  nid: 1,
+  posts: [{ _id: "post_id" }],
+};
+
+const TAG_STUB_WITHOUT_POSTS = {
+  ...TAG_STUB,
+  posts: [],
+};
+
+export { TAG_INPUT_STUB, TAG_STUB, TAG_STUB_WITHOUT_POSTS };


### PR DESCRIPTION
- #21

## ✨ **구현 기능 명세**
- tag service 테스트 및 비즈니스 로직을 생성합니다.
- TDD 형식으로 진행했으며 차후 게시글 관련 테스트나 비즈니스 로직을 작성화면서 변경될 수 있습니다.
- Tag는 직접 삭제하는 로직이나 내부 name을 변경하는 로직이 존재하지 않습니다.
- 특정 게시글의 id를 받아 태그 내부에 추가하거나 삭제하는 로직을 작성했습니다.
- 태그를 참조하고 있는 게시글이 존재하지 않을 경우에는 태그가 자동으로 삭제되도록 설정합니다.

## 🌄 **스크린샷**
<img width="802" alt="image" src="https://github.com/seoko97/SEOKO-server/assets/60173534/1a165895-0d23-4851-ac56-a00dd3d5b1ce">
