### PR TITLE
Tag Controller 테스트 및 비즈니스 로직 생성

### DIFF
--- a/src/routes/series/series.controller.ts
+++ b/src/routes/series/series.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post } from "@nestjs/common";
+import { Body, Controller, Get, Param, Patch, Post } from "@nestjs/common";
 
 import { Public } from "@/common/decorators";
 import { UpdateSeriesDto } from "@/routes/series/dto/update-series.dto";
@@ -20,7 +20,7 @@ export class SeriesController {
     return await this.seriesService.getByNumId(Number(numId));
   }
 
-  @Post(":_id")
+  @Patch(":_id")
   async updateSeries(@Param("_id") _id: string, @Body() updateSeriesDto: UpdateSeriesDto) {
     const input = {
       ...updateSeriesDto,

--- a/src/routes/tag/tag.controller.ts
+++ b/src/routes/tag/tag.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param } from "@nestjs/common";
+
+import { TagService } from "@/routes/tag/tag.service";
+
+@Controller("tag")
+export class TagController {
+  constructor(private readonly tagService: TagService) {}
+
+  @Get()
+  async getAll() {
+    return await this.tagService.getAll();
+  }
+
+  @Get(":name")
+  async getByName(@Param("name") name: string) {
+    return await this.tagService.getByName(name);
+  }
+}

--- a/src/routes/tag/tag.controller.ts
+++ b/src/routes/tag/tag.controller.ts
@@ -2,17 +2,17 @@ import { Controller, Get, Param } from "@nestjs/common";
 
 import { TagService } from "@/routes/tag/tag.service";
 
-@Controller("tag")
+@Controller("tags")
 export class TagController {
   constructor(private readonly tagService: TagService) {}
 
   @Get()
   async getAll() {
-    return await this.tagService.getAll();
+    return this.tagService.getAll();
   }
 
   @Get(":name")
   async getByName(@Param("name") name: string) {
-    return await this.tagService.getByName(name);
+    return this.tagService.getByName(name);
   }
 }

--- a/src/routes/tag/tag.repository.ts
+++ b/src/routes/tag/tag.repository.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
 
 import { SequenceRepository } from "@/common/sequence/sequence.repository";
 import { Tag, TagDocument, TagModel } from "@/routes/tag/tag.schema";
@@ -7,7 +8,7 @@ import { GET_TAGS_OPTIONS } from "@/utils/constants/tag";
 @Injectable()
 export class TagRepository {
   constructor(
-    @Inject(Tag.name) private readonly tagModel: TagModel,
+    @InjectModel(Tag.name) private readonly tagModel: TagModel,
     private readonly sequenceRepository: SequenceRepository,
   ) {}
 
@@ -47,9 +48,7 @@ export class TagRepository {
   }
 
   async getByName(name: string) {
-    const tag = await this.tagModel.findOne({ name }).populate("posts");
-
-    return tag[0];
+    return this.tagModel.findOne({ name }).populate("posts");
   }
 
   async getAll() {

--- a/test/routes/series/series.service.spec.ts
+++ b/test/routes/series/series.service.spec.ts
@@ -16,6 +16,7 @@ jest.mock("@/routes/series/series.repository");
 
 describe("SeriesService", () => {
   let service: SeriesService;
+  let repository: SeriesRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,6 +24,7 @@ describe("SeriesService", () => {
     }).compile();
 
     service = module.get<SeriesService>(SeriesService);
+    repository = module.get<SeriesRepository>(SeriesRepository);
 
     jest.clearAllMocks();
   });
@@ -36,8 +38,8 @@ describe("SeriesService", () => {
     let repositoryGetByNameSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      repositoryCreateSpy = jest.spyOn(SeriesRepository.prototype, "create");
-      repositoryGetByNameSpy = jest.spyOn(SeriesRepository.prototype, "getByName");
+      repositoryCreateSpy = jest.spyOn(repository, "create");
+      repositoryGetByNameSpy = jest.spyOn(repository, "getByName");
     });
 
     it("성공", async () => {
@@ -76,9 +78,9 @@ describe("SeriesService", () => {
     let repositoryGetByIdSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      repositoryUpdateSpy = jest.spyOn(SeriesRepository.prototype, "update");
-      repositoryUpdateToPushPostSpy = jest.spyOn(SeriesRepository.prototype, "updateToPushPost");
-      repositoryGetByIdSpy = jest.spyOn(SeriesRepository.prototype, "getById");
+      repositoryUpdateSpy = jest.spyOn(repository, "update");
+      repositoryUpdateToPushPostSpy = jest.spyOn(repository, "updateToPushPost");
+      repositoryGetByIdSpy = jest.spyOn(repository, "getById");
     });
 
     describe("성공", () => {
@@ -156,8 +158,8 @@ describe("SeriesService", () => {
     let repositoryGetByIdSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      repositoryDeleteSpy = jest.spyOn(SeriesRepository.prototype, "delete");
-      repositoryGetByIdSpy = jest.spyOn(SeriesRepository.prototype, "getById");
+      repositoryDeleteSpy = jest.spyOn(repository, "delete");
+      repositoryGetByIdSpy = jest.spyOn(repository, "getById");
     });
 
     it("성공", async () => {
@@ -195,8 +197,8 @@ describe("SeriesService", () => {
     let repositoryGetByNumIdSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      repositoryGetByAllSpy = jest.spyOn(SeriesRepository.prototype, "getByAll");
-      repositoryGetByNumIdSpy = jest.spyOn(SeriesRepository.prototype, "getByNumId");
+      repositoryGetByAllSpy = jest.spyOn(repository, "getByAll");
+      repositoryGetByNumIdSpy = jest.spyOn(repository, "getByNumId");
     });
 
     describe("성공", () => {

--- a/test/routes/tag/tag.controller.spec.ts
+++ b/test/routes/tag/tag.controller.spec.ts
@@ -1,0 +1,52 @@
+import { Test, TestingModule } from "@nestjs/testing";
+
+import { TAG_STUB } from "test/utils/stub";
+
+import { TagController } from "@/routes/tag/tag.controller";
+import { TagService } from "@/routes/tag/tag.service";
+
+jest.mock("@/routes/tag/tag.service");
+
+describe("TagController", () => {
+  let controller: TagController;
+  let service: TagService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TagController],
+      providers: [TagService],
+    }).compile();
+
+    controller = module.get<TagController>(TagController);
+    service = module.get<TagService>(TagService);
+
+    jest.clearAllMocks();
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+
+  it("태그 전체 조회", async () => {
+    const serviceGetAllSpy: jest.SpyInstance = jest.spyOn(service, "getAll");
+    serviceGetAllSpy.mockResolvedValueOnce([TAG_STUB]);
+
+    const tags = await controller.getAll();
+
+    expect(tags).toEqual([TAG_STUB]);
+    expect(serviceGetAllSpy).toHaveBeenCalled();
+    expect(serviceGetAllSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("태그 이름으로 조회", async () => {
+    const serviceGetByNameSpy: jest.SpyInstance = jest.spyOn(service, "getByName");
+    serviceGetByNameSpy.mockResolvedValueOnce(TAG_STUB);
+
+    const tag = await controller.getByName("태그 이름");
+
+    expect(tag).toEqual(TAG_STUB);
+    expect(serviceGetByNameSpy).toHaveBeenCalled();
+    expect(serviceGetByNameSpy).toHaveBeenCalledTimes(1);
+    expect(serviceGetByNameSpy).toHaveBeenCalledWith("태그 이름");
+  });
+});


### PR DESCRIPTION
-  Closes #21

## ✨ **구현 기능 명세**
- tag controller 테스트 및 비즈니스 로직을 생성합니다.
- TDD 형식으로 진행하였습니다.
- tag에 대한 생성과 변경은 Post 생성/수정시 발생하기 떄문에 API 요청이  존재하지 않습니다.

## 🌄 **스크린샷**
<img width="456" alt="image" src="https://github.com/seoko97/SEOKO-server/assets/60173534/ec199e59-c65b-4bc2-86ec-5fc14dfd3e69">
