### PR TITLE
Post Service 테스트 코드 및 비즈니스 로직 생성

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,5 +52,6 @@ module.exports = {
         },
       },
     ],
+    "@typescript-eslint/no-unused-vars": ["error", { varsIgnorePattern: "_" }],
   },
 };

--- a/src/common/guards/jwt-auth.guard.ts
+++ b/src/common/guards/jwt-auth.guard.ts
@@ -8,7 +8,7 @@ import { AUTH_ERROR, IS_PUBLIC_KEY } from "@/utils/constants";
 
 const generateJwtAuthGuard = (key: string): Type<IAuthGuard> => {
   @Injectable()
-  class JwtAuthGuard extends AuthGuard(key) {
+  class JwtAuthGuard extends AuthGuard(`jwt-${key}`) {
     HEADER: string;
 
     constructor(private readonly configService: ConfigService) {
@@ -53,7 +53,7 @@ const generateJwtAuthGuard = (key: string): Type<IAuthGuard> => {
 };
 
 @Injectable()
-export class AccessJwtAuthGuard extends generateJwtAuthGuard(`jwt-${EJwtTokenType.ACCESS}`) {
+export class AccessJwtAuthGuard extends generateJwtAuthGuard(EJwtTokenType.ACCESS) {
   constructor(
     private readonly reflector: Reflector,
     private readonly configService: ConfigService,
@@ -75,4 +75,4 @@ export class AccessJwtAuthGuard extends generateJwtAuthGuard(`jwt-${EJwtTokenTyp
   }
 }
 
-export const RefreshJwtAuthGuard = generateJwtAuthGuard(`jwt-${EJwtTokenType.REFRESH}`);
+export const RefreshJwtAuthGuard = generateJwtAuthGuard(EJwtTokenType.REFRESH);

--- a/src/routes/post/dto/create-post.dto.ts
+++ b/src/routes/post/dto/create-post.dto.ts
@@ -1,0 +1,14 @@
+import { PickType } from "@nestjs/mapped-types";
+
+import { IsArray, IsString } from "class-validator";
+
+import { Post } from "@/routes/post/post.schema";
+
+export class CreatePostDto extends PickType(Post, ["title", "content", "thumbnail"]) {
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsString()
+  series?: string;
+}

--- a/src/routes/post/dto/get-posts.dto.ts
+++ b/src/routes/post/dto/get-posts.dto.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from "@nestjs/common";
+
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+
+export const IsOptionalCustom = (_decorator: PropertyDecorator) => {
+  return applyDecorators(IsOptional(), IsNotEmpty(), _decorator);
+};
+
+export class GetPostsDto {
+  @IsOptionalCustom(IsString())
+  series?: string;
+
+  @IsOptionalCustom(IsNumber())
+  offset?: number;
+
+  @IsOptionalCustom(IsNumber())
+  limit?: number;
+
+  @IsOptionalCustom(IsString())
+  tag?: string;
+
+  @IsOptionalCustom(IsString())
+  text?: string;
+}

--- a/src/routes/post/dto/update-post.dto.ts
+++ b/src/routes/post/dto/update-post.dto.ts
@@ -1,0 +1,18 @@
+import { PickType } from "@nestjs/mapped-types";
+
+import { IsArray, IsString } from "class-validator";
+
+import { Post } from "@/routes/post/post.schema";
+
+export class UpdatePostDto extends PickType(Post, ["_id", "title", "content", "thumbnail"]) {
+  @IsString()
+  series?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  deleteTags?: string[];
+
+  @IsArray()
+  @IsString({ each: true })
+  addTags?: string[];
+}

--- a/src/routes/post/post.module.ts
+++ b/src/routes/post/post.module.ts
@@ -1,9 +1,24 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 
+import { SequenceModule } from "@/common/sequence/sequence.module";
+import { PostRepository } from "@/routes/post/post.repository";
 import { Post, PostSchema } from "@/routes/post/post.schema";
+import { SeriesModule } from "@/routes/series/series.module";
+import { TagModule } from "@/routes/tag/tag.module";
+
+import { PostController } from "./post.controller";
+import { PostService } from "./post.service";
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: Post.name, schema: PostSchema }])],
+  imports: [
+    MongooseModule.forFeature([{ name: Post.name, schema: PostSchema }]),
+    TagModule,
+    SeriesModule,
+    SequenceModule,
+  ],
+  providers: [PostService, PostRepository],
+  controllers: [PostController],
+  exports: [PostService],
 })
 export class PostModule {}

--- a/src/routes/post/post.module.ts
+++ b/src/routes/post/post.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 
 import { SequenceModule } from "@/common/sequence/sequence.module";
@@ -13,8 +13,8 @@ import { PostService } from "./post.service";
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Post.name, schema: PostSchema }]),
+    forwardRef(() => SeriesModule),
     TagModule,
-    SeriesModule,
     SequenceModule,
   ],
   providers: [PostService, PostRepository],

--- a/src/routes/post/post.repository.ts
+++ b/src/routes/post/post.repository.ts
@@ -1,0 +1,80 @@
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+
+import { FilterQuery } from "mongoose";
+
+import { SequenceRepository } from "@/common/sequence/sequence.repository";
+import { UpdatePostDto } from "@/routes/post/dto/update-post.dto";
+import { Post, PostDocument, PostModel } from "@/routes/post/post.schema";
+import { TagDocument } from "@/routes/tag/tag.schema";
+
+@Injectable()
+export class PostRepository {
+  constructor(
+    @InjectModel(Post.name) private readonly postModel: PostModel,
+    private readonly sequenceRepository: SequenceRepository,
+  ) {}
+
+  async save(post: PostDocument) {
+    return post.save();
+  }
+
+  async create(createPostDto: any) {
+    const nid = await this.sequenceRepository.getNextSequence("series");
+
+    return this.postModel.create({ nid, ...createPostDto });
+  }
+
+  async delete(_id: string) {
+    return this.postModel.deleteOne({ _id });
+  }
+
+  async update(updatePostDto: UpdatePostDto) {
+    return this.postModel.updateOne({ _id: updatePostDto._id }, updatePostDto);
+  }
+
+  async deleteSeriesInPosts(seriesId: string) {
+    return this.postModel.updateMany({ series: seriesId }, { series: null });
+  }
+
+  async pushTags(postId: string, tags: TagDocument[]) {
+    return this.postModel.updateOne({ _id: postId }, { $push: { tags: { $each: tags } } });
+  }
+
+  async pullTags(postId: string, tags: TagDocument[]) {
+    return this.postModel.updateOne({ _id: postId }, { $pull: { tags: { $in: tags } } });
+  }
+
+  async increaseToLikes(postId: string, ip: string) {
+    return this.postModel.updateOne({ _id: postId }, { $push: { likes: ip } });
+  }
+
+  async decreaseToLikes(postId: string, ip: string) {
+    return this.postModel.updateOne({ _id: postId }, { $pull: { likes: ip } });
+  }
+
+  async increaseToViews(postId: string, ip: string) {
+    return this.postModel.updateOne({ _id: postId }, { $push: { views: ip } });
+  }
+
+  async getAll(options: FilterQuery<PostDocument>, limit: number, offset: number) {
+    return this.postModel.find(options).populate("tags").skip(offset).limit(limit);
+  }
+
+  async getById(_id: string) {
+    return this.postModel.findOne({ _id }).populate("tags").populate("series");
+  }
+
+  async getByNumId(nid: number) {
+    return this.postModel.findOne({ nid }).populate("tags").populate("series");
+  }
+
+  async getSibling(targetNid: number) {
+    const [prev, next] = await Promise.all([
+      this.postModel.findOne({ nid: { $lt: targetNid } }),
+      this.postModel.findOne({ nid: { $gt: targetNid } }),
+    ]);
+
+    return { prev, next };
+  }
+}

--- a/src/routes/post/post.schema.ts
+++ b/src/routes/post/post.schema.ts
@@ -27,6 +27,20 @@ export class Post extends BaseSchema {
   series?: Types.ObjectId;
 
   @Prop({
+    type: [{ type: String }],
+    required: false,
+    default: [],
+  })
+  likes?: string[];
+
+  @Prop({
+    type: [{ type: String }],
+    required: false,
+    default: [],
+  })
+  views?: string[];
+
+  @Prop({
     type: [{ type: Types.ObjectId }],
     ref: "Tag",
     required: false,

--- a/src/routes/post/post.schema.ts
+++ b/src/routes/post/post.schema.ts
@@ -4,6 +4,7 @@ import { IsString } from "class-validator";
 import { Document, Model, Types } from "mongoose";
 
 import { BaseSchema } from "@/common/schema/base.schema";
+import { Series } from "@/routes/series/series.schema";
 import { Tag } from "@/routes/tag/tag.schema";
 
 export type PostDocument = Post & Document;
@@ -23,8 +24,13 @@ export class Post extends BaseSchema {
   @Prop({ required: true })
   thumbnail!: string;
 
-  @Prop({ type: Types.ObjectId, ref: "Series", required: false })
-  series?: Types.ObjectId;
+  @Prop({
+    type: Types.ObjectId,
+    ref: Series.name,
+    required: false,
+    default: null,
+  })
+  series?: Series;
 
   @Prop({
     type: [{ type: String }],
@@ -42,7 +48,7 @@ export class Post extends BaseSchema {
 
   @Prop({
     type: [{ type: Types.ObjectId }],
-    ref: "Tag",
+    ref: Tag.name,
     required: false,
     default: [],
   })

--- a/src/routes/post/post.service.ts
+++ b/src/routes/post/post.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from "@nestjs/common";
+
+import { POST_STUB } from "test/utils/stub";
+
+import { PostRepository } from "@/routes/post/post.repository";
+import { SeriesService } from "@/routes/series/series.service";
+import { TagService } from "@/routes/tag/tag.service";
+
+@Injectable()
+export class PostService {
+  constructor(
+    private readonly postRepository: PostRepository,
+    private readonly tagService: TagService,
+    private readonly seriesService: SeriesService,
+  ) {}
+
+  async create(createPostDto: any) {
+    return POST_STUB;
+  }
+
+  async delete(_id: string) {
+    return true;
+  }
+
+  async update(updatePostDto: any) {
+    return POST_STUB;
+  }
+
+  async increaseToLikes(postId: string, ip: string) {
+    return true;
+  }
+
+  async decreaseToLikes(postId: string, ip: string) {
+    return true;
+  }
+
+  async increaseToViews(postId: string, ip: string) {
+    return true;
+  }
+
+  async getAll(getPostsDto: any) {
+    return [POST_STUB];
+  }
+
+  async getByNumId(nid: number) {
+    return POST_STUB;
+  }
+
+  async getSiblings(targetNid: string) {
+    return [POST_STUB, POST_STUB];
+  }
+}

--- a/src/routes/post/post.service.ts
+++ b/src/routes/post/post.service.ts
@@ -1,52 +1,140 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Inject, Injectable, forwardRef } from "@nestjs/common";
 
-import { POST_STUB } from "test/utils/stub";
-
+import { CreatePostDto } from "@/routes/post/dto/create-post.dto";
+import { GetPostsDto } from "@/routes/post/dto/get-posts.dto";
+import { UpdatePostDto } from "@/routes/post/dto/update-post.dto";
 import { PostRepository } from "@/routes/post/post.repository";
+import { PostDocument } from "@/routes/post/post.schema";
 import { SeriesService } from "@/routes/series/series.service";
 import { TagService } from "@/routes/tag/tag.service";
+import { POST_ERROR } from "@/utils/constants";
+import { filterQueryByPosts } from "@/utils/filterQueryByPosts";
 
 @Injectable()
 export class PostService {
   constructor(
     private readonly postRepository: PostRepository,
     private readonly tagService: TagService,
-    private readonly seriesService: SeriesService,
+    @Inject(forwardRef(() => SeriesService)) private readonly seriesService: SeriesService,
   ) {}
 
-  async create(createPostDto: any) {
-    return POST_STUB;
+  async create(createPostDto: CreatePostDto) {
+    const { tags: tagNames, series: seriesName, ...rest } = createPostDto;
+
+    let post: PostDocument;
+
+    try {
+      post = await this.postRepository.create(rest);
+
+      if (seriesName) {
+        post.series = await this.seriesService.pushPostIdInSeries(seriesName, post._id);
+      }
+
+      if (tagNames?.length) {
+        post.tags = await this.tagService.pushPostIdInTags(tagNames, post._id);
+      }
+
+      await this.postRepository.save(post);
+    } catch (error) {
+      throw new BadRequestException(error?.massage || POST_ERROR.FAIL_CREATE);
+    }
+
+    await post.populate("tags");
+    await post.populate("series");
+
+    return post;
   }
 
   async delete(_id: string) {
+    const post = await this.postRepository.getById(_id);
+
+    if (!post) {
+      throw new BadRequestException(POST_ERROR.NOT_FOUND);
+    }
+
+    const tagNames = post.tags.map((tag) => tag.name);
+
+    await this.seriesService.pullPostIdInSeries(post.series.name, _id);
+    await this.tagService.pullPostIdInTags(tagNames, _id);
+    await this.postRepository.delete(_id);
+
     return true;
   }
 
-  async update(updatePostDto: any) {
-    return POST_STUB;
+  async update(updatePostDto: UpdatePostDto) {
+    const _id = updatePostDto._id;
+    const { addTags = [], deleteTags = [], series: seriesName, ...rest } = updatePostDto;
+
+    const post = await this.postRepository.getById(_id);
+
+    if (!post) {
+      throw new BadRequestException(POST_ERROR.NOT_FOUND);
+    }
+
+    const input = { ...rest, series: null };
+    const prevSeriesName = post.series?.name ?? null;
+
+    try {
+      // 기존에 시리즈가 존재하고 입력받은 시리즈와 다르다면
+      if (prevSeriesName && prevSeriesName !== seriesName) {
+        await this.seriesService.pullPostIdInSeries(prevSeriesName, _id);
+      }
+
+      // 입력받은 시리즈가 null이 아니고 기존 시리즈가 다르다면
+      if (seriesName && prevSeriesName !== seriesName) {
+        input.series = await this.seriesService.pushPostIdInSeries(seriesName, _id);
+      }
+
+      await this.postRepository.update(input);
+
+      const [dTags, aTags] = await Promise.all([
+        this.tagService.pullPostIdInTags(deleteTags, _id),
+        this.tagService.pushPostIdInTags(addTags, _id),
+      ]);
+
+      await this.postRepository.pushTags(_id, aTags);
+      await this.postRepository.pullTags(_id, dTags);
+    } catch (error) {
+      console.log(error.message);
+      throw new BadRequestException(error?.massage || POST_ERROR.FAIL_UPDATE);
+    }
+
+    return this.postRepository.getById(_id);
+  }
+
+  async deleteSeriesInPosts(seriesId: string) {
+    return this.postRepository.deleteSeriesInPosts(seriesId);
   }
 
   async increaseToLikes(postId: string, ip: string) {
-    return true;
+    return this.postRepository.increaseToLikes(postId, ip);
   }
 
   async decreaseToLikes(postId: string, ip: string) {
-    return true;
+    return this.postRepository.decreaseToLikes(postId, ip);
   }
 
   async increaseToViews(postId: string, ip: string) {
-    return true;
+    return this.postRepository.increaseToViews(postId, ip);
   }
 
-  async getAll(getPostsDto: any) {
-    return [POST_STUB];
+  async getAll(getPostsDto: GetPostsDto) {
+    const { offset = 0, limit = 10, ...rest } = getPostsDto;
+
+    const options = filterQueryByPosts(rest);
+
+    return this.postRepository.getAll(options, limit, offset);
   }
 
   async getByNumId(nid: number) {
-    return POST_STUB;
+    return this.postRepository.getByNumId(nid);
   }
 
-  async getSiblings(targetNid: string) {
-    return [POST_STUB, POST_STUB];
+  async getById(_id: string) {
+    return this.postRepository.getById(_id);
+  }
+
+  async getSibling(targetNid: number) {
+    return this.postRepository.getSibling(targetNid);
   }
 }

--- a/src/routes/series/series.controller.ts
+++ b/src/routes/series/series.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Patch, Post } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, Patch } from "@nestjs/common";
 
 import { Public } from "@/common/decorators";
 import { UpdateSeriesDto } from "@/routes/series/dto/update-series.dto";
@@ -30,7 +30,7 @@ export class SeriesController {
     return await this.seriesService.update(input);
   }
 
-  @Post("_id")
+  @Delete("_id")
   async deleteSeries(@Param("_id") _id: string) {
     return await this.seriesService.delete(_id);
   }

--- a/src/routes/series/series.module.ts
+++ b/src/routes/series/series.module.ts
@@ -1,7 +1,8 @@
-import { Module } from "@nestjs/common";
+import { Module, forwardRef } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 
 import { SequenceModule } from "@/common/sequence/sequence.module";
+import { PostModule } from "@/routes/post/post.module";
 import { SeriesRepository } from "@/routes/series/series.repository";
 import { Series, SeriesSchema } from "@/routes/series/series.schema";
 
@@ -11,10 +12,11 @@ import { SeriesService } from "./series.service";
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Series.name, schema: SeriesSchema }]),
+    forwardRef(() => PostModule),
     SequenceModule,
   ],
   providers: [SeriesService, SeriesRepository],
   controllers: [SeriesController],
-  exports: [SeriesService, SeriesRepository],
+  exports: [SeriesService],
 })
 export class SeriesModule {}

--- a/src/routes/series/series.repository.ts
+++ b/src/routes/series/series.repository.ts
@@ -16,12 +16,7 @@ export class SeriesRepository {
   async create(createSeriesDto: CreateSeriesDto) {
     const nid = await this.sequenceRepository.getNextSequence("series");
 
-    const input = {
-      nid,
-      ...createSeriesDto,
-    };
-
-    return this.seriesModel.create(input);
+    return this.seriesModel.create({ nid, ...createSeriesDto });
   }
 
   async update(updateSeriesDto: UpdateSeriesDtoWithId) {

--- a/src/routes/series/series.repository.ts
+++ b/src/routes/series/series.repository.ts
@@ -25,8 +25,12 @@ export class SeriesRepository {
     return this.seriesModel.updateOne({ _id }, rest);
   }
 
-  async updateToPushPost(seriesId: string, postId: string) {
+  async pushPostId(seriesId: string, postId: string) {
     return this.seriesModel.updateOne({ _id: seriesId }, { $push: { posts: postId } });
+  }
+
+  async pullPostId(seriesId: string, postId: string) {
+    return this.seriesModel.updateOne({ _id: seriesId }, { $pull: { posts: postId } });
   }
 
   async delete(_id: string) {

--- a/src/routes/series/series.repository.ts
+++ b/src/routes/series/series.repository.ts
@@ -48,4 +48,14 @@ export class SeriesRepository {
   async getByName(name: string) {
     return this.seriesModel.findOne({ name });
   }
+
+  async findOrCreate(name: string) {
+    const series = await this.getByName(name);
+
+    if (series) {
+      return series;
+    }
+
+    return this.create({ name });
+  }
 }

--- a/src/routes/series/series.repository.ts
+++ b/src/routes/series/series.repository.ts
@@ -25,11 +25,11 @@ export class SeriesRepository {
     return this.seriesModel.updateOne({ _id }, rest);
   }
 
-  async pushPostId(seriesId: string, postId: string) {
+  async pushPostIdInSeries(seriesId: string, postId: string) {
     return this.seriesModel.updateOne({ _id: seriesId }, { $push: { posts: postId } });
   }
 
-  async pullPostId(seriesId: string, postId: string) {
+  async pullPostIdInSeries(seriesId: string, postId: string) {
     return this.seriesModel.updateOne({ _id: seriesId }, { $pull: { posts: postId } });
   }
 

--- a/src/routes/series/series.schema.ts
+++ b/src/routes/series/series.schema.ts
@@ -16,8 +16,8 @@ export class Series extends BaseSchema {
   name!: string;
 
   @IsString()
-  @Prop({ required: true })
-  thumbnail!: string;
+  @Prop({ required: false, default: null })
+  thumbnail?: string;
 
   @Prop({
     ref: "Post",

--- a/src/routes/series/series.service.ts
+++ b/src/routes/series/series.service.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 
+import { PostService } from "@/routes/post/post.service";
 import { CreateSeriesDto } from "@/routes/series/dto/create-series.dto";
 import { UpdateSeriesDtoWithId } from "@/routes/series/dto/update-series.dto";
 import { SeriesRepository } from "@/routes/series/series.repository";
@@ -7,7 +8,10 @@ import { SERIES_ERROR } from "@/utils/constants";
 
 @Injectable()
 export class SeriesService {
-  constructor(private readonly seriesRepository: SeriesRepository) {}
+  constructor(
+    private readonly seriesRepository: SeriesRepository,
+    private readonly postService: PostService,
+  ) {}
 
   async create(createSeriesDto: CreateSeriesDto) {
     const { name } = createSeriesDto;
@@ -50,6 +54,7 @@ export class SeriesService {
   async delete(_id: string) {
     await this.checkSeriesById(_id);
 
+    await this.postService.deleteSeriesInPosts(_id);
     await this.seriesRepository.delete(_id);
 
     return true;

--- a/src/routes/series/series.service.ts
+++ b/src/routes/series/series.service.ts
@@ -29,22 +29,22 @@ export class SeriesService {
     return this.seriesRepository.getById(updateSeriesDto._id);
   }
 
-  async pushPostId(name: string, postId: string) {
+  async pushPostIdInSeries(name: string, postId: string) {
     const series = await this.seriesRepository.findOrCreate(name);
 
-    await this.seriesRepository.pushPostId(series._id, postId);
+    await this.seriesRepository.pushPostIdInSeries(series._id, postId);
 
     return series;
   }
 
-  async pullPostId(name: string, postId: string) {
+  async pullPostIdInSeries(name: string, postId: string) {
     const series = await this.seriesRepository.getByName(name);
 
     if (!series) {
       throw new BadRequestException(SERIES_ERROR.NOT_FOUND);
     }
 
-    await this.seriesRepository.pullPostId(series._id, postId);
+    await this.seriesRepository.pullPostIdInSeries(series._id, postId);
   }
 
   async delete(_id: string) {

--- a/src/routes/series/series.service.ts
+++ b/src/routes/series/series.service.ts
@@ -29,12 +29,22 @@ export class SeriesService {
     return this.seriesRepository.getById(updateSeriesDto._id);
   }
 
-  async updateToPushPost(name: string, postId: string) {
+  async pushPostId(name: string, postId: string) {
     const series = await this.seriesRepository.findOrCreate(name);
 
-    await this.seriesRepository.updateToPushPost(series._id, postId);
+    await this.seriesRepository.pushPostId(series._id, postId);
 
-    return this.seriesRepository.getById(name);
+    return series;
+  }
+
+  async pullPostId(name: string, postId: string) {
+    const series = await this.seriesRepository.getByName(name);
+
+    if (!series) {
+      throw new BadRequestException(SERIES_ERROR.NOT_FOUND);
+    }
+
+    await this.seriesRepository.pullPostId(series._id, postId);
   }
 
   async delete(_id: string) {

--- a/src/routes/series/series.service.ts
+++ b/src/routes/series/series.service.ts
@@ -29,12 +29,12 @@ export class SeriesService {
     return this.seriesRepository.getById(updateSeriesDto._id);
   }
 
-  async updateToPushPost(seriesId: string, postId: string) {
-    await this.checkSeriesById(seriesId);
+  async updateToPushPost(name: string, postId: string) {
+    const series = await this.seriesRepository.findOrCreate(name);
 
-    await this.seriesRepository.updateToPushPost(seriesId, postId);
+    await this.seriesRepository.updateToPushPost(series._id, postId);
 
-    return this.seriesRepository.getById(seriesId);
+    return this.seriesRepository.getById(name);
   }
 
   async delete(_id: string) {

--- a/src/routes/tag/tag.repository.ts
+++ b/src/routes/tag/tag.repository.ts
@@ -19,7 +19,7 @@ export class TagRepository {
     );
   }
 
-  async pullPostIdInTagNames(tagNames: string[], postId: string) {
+  async pullPostIdInTags(tagNames: string[], postId: string) {
     await this.tagModel
       .updateMany({ name: { $in: tagNames } }, { $pull: { posts: postId } })
       .exec();

--- a/src/routes/tag/tag.service.ts
+++ b/src/routes/tag/tag.service.ts
@@ -14,7 +14,7 @@ export class TagService {
     return this.tagRepository.getByName(name);
   }
 
-  async pushPostIdInTagNames(tagNames: string[], postId: string) {
+  async pushPostIdInTags(tagNames: string[], postId: string) {
     const tags = await Promise.all(
       tagNames.map((tagName) => this.tagRepository.findOrCreate(tagName)),
     );
@@ -24,8 +24,8 @@ export class TagService {
     return tags;
   }
 
-  async pullPostIdInTagNames(tagNames: string[], postId: string) {
-    await this.tagRepository.pullPostIdInTagNames(tagNames, postId);
+  async pullPostIdInTags(tagNames: string[], postId: string) {
+    await this.tagRepository.pullPostIdInTags(tagNames, postId);
 
     return this.tagRepository.getAllByTagNames(tagNames);
   }

--- a/src/utils/constants/index.ts
+++ b/src/utils/constants/index.ts
@@ -1,3 +1,4 @@
 export * from "./user";
 export * from "./auth";
 export * from "./series";
+export * from "./post";

--- a/src/utils/constants/post.ts
+++ b/src/utils/constants/post.ts
@@ -1,0 +1,7 @@
+const POST_ERROR = {
+  NOT_FOUND: "존재하지 않는 게시글입니다.",
+  FAIL_CREATE: "게시글 생성에 실패했습니다.",
+  FAIL_UPDATE: "게시글 수정에 실패했습니다.",
+};
+
+export { POST_ERROR };

--- a/src/utils/filterQueryByPosts.ts
+++ b/src/utils/filterQueryByPosts.ts
@@ -1,0 +1,29 @@
+import { FilterQuery } from "mongoose";
+
+import { GetPostsDto } from "@/routes/post/dto/get-posts.dto";
+import { PostDocument } from "@/routes/post/post.schema";
+
+const filterQueryByPosts = (dto: GetPostsDto) => {
+  const { series, tag, text } = dto;
+
+  const query: FilterQuery<PostDocument> = {};
+
+  if (series) {
+    query.series = series;
+  }
+
+  if (tag) {
+    query.tags = { $elemMatch: { name: tag } };
+  }
+
+  if (text) {
+    query.$or = [
+      { title: { $regex: text, $options: "i" } },
+      { content: { $regex: text, $options: "i" } },
+    ];
+  }
+
+  return query;
+};
+
+export { filterQueryByPosts };

--- a/test/routes/post/post.service.spec.ts
+++ b/test/routes/post/post.service.spec.ts
@@ -1,0 +1,460 @@
+import { BadRequestException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+
+import {
+  POST_CREATE_STUB,
+  POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES,
+  POST_STUB,
+  POST_UPDATE_STUB,
+  SERIES_STUB,
+  TAG_STUB,
+} from "test/utils/stub";
+
+import { PostRepository } from "@/routes/post/post.repository";
+import { PostService } from "@/routes/post/post.service";
+import { SeriesService } from "@/routes/series/series.service";
+import { TagService } from "@/routes/tag/tag.service";
+import { POST_ERROR } from "@/utils/constants";
+import { filterQueryByPosts } from "@/utils/filterQueryByPosts";
+
+jest.mock("@/routes/post/post.repository");
+jest.mock("@/routes/series/series.service");
+jest.mock("@/routes/tag/tag.service");
+
+describe("PostService", () => {
+  let postRepository: PostRepository;
+  let postService: PostService;
+  let seriesService: SeriesService;
+  let tagService: TagService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostService, PostRepository, SeriesService, TagService],
+    }).compile();
+
+    postRepository = module.get<PostRepository>(PostRepository);
+    postService = module.get<PostService>(PostService);
+    seriesService = module.get<SeriesService>(SeriesService);
+    tagService = module.get<TagService>(TagService);
+
+    jest.clearAllMocks();
+  });
+
+  it("should be defined", () => {
+    expect(postRepository).toBeDefined();
+    expect(postService).toBeDefined();
+    expect(seriesService).toBeDefined();
+    expect(tagService).toBeDefined();
+  });
+
+  describe("게시글 생성", () => {
+    let postRepositoryCreateSpy: jest.SpyInstance;
+    let seriesServicePushPostSpy: jest.SpyInstance;
+    let tagServicePushPostIdInTagsSpy: jest.SpyInstance;
+
+    let POST;
+
+    beforeEach(() => {
+      POST = {
+        ...POST_STUB,
+        save: jest.fn().mockResolvedValue(POST_STUB),
+        populate: jest.fn().mockResolvedValue(POST_STUB),
+      };
+
+      postRepositoryCreateSpy = jest.spyOn(postRepository, "create");
+      seriesServicePushPostSpy = jest.spyOn(seriesService, "pushPostIdInSeries");
+      tagServicePushPostIdInTagsSpy = jest.spyOn(tagService, "pushPostIdInTags");
+    });
+
+    it("성공", async () => {
+      postRepositoryCreateSpy.mockResolvedValueOnce(POST);
+      seriesServicePushPostSpy.mockResolvedValueOnce(SERIES_STUB);
+      tagServicePushPostIdInTagsSpy.mockResolvedValueOnce([TAG_STUB]);
+
+      const { tags, series, ...rest } = POST_CREATE_STUB;
+
+      const post = await postService.create(POST_CREATE_STUB);
+
+      expect(post).toEqual(POST);
+      expect(postRepositoryCreateSpy).toBeCalledTimes(1);
+      expect(postRepositoryCreateSpy).toBeCalledWith(rest);
+      expect(seriesServicePushPostSpy).toBeCalledTimes(1);
+      expect(seriesServicePushPostSpy).toBeCalledWith(series, POST._id);
+      expect(tagServicePushPostIdInTagsSpy).toBeCalledTimes(1);
+      expect(tagServicePushPostIdInTagsSpy).toBeCalledWith(tags, POST._id);
+    });
+
+    it("성공 - 태그, 시리즈 없을 때", async () => {
+      postRepositoryCreateSpy.mockResolvedValueOnce(POST);
+
+      const post = await postService.create(POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES);
+
+      expect(post).toEqual(POST);
+      expect(postRepositoryCreateSpy).toBeCalledTimes(1);
+      expect(postRepositoryCreateSpy).toBeCalledWith(POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES);
+      expect(seriesServicePushPostSpy).toBeCalledTimes(0);
+      expect(tagServicePushPostIdInTagsSpy).toBeCalledTimes(0);
+    });
+
+    it("실패 - 이미 존재하는 게시글", async () => {
+      postRepositoryCreateSpy.mockRejectedValueOnce(
+        new BadRequestException(POST_ERROR.FAIL_CREATE),
+      );
+
+      const { tags: _, series: __, ...rest } = POST_CREATE_STUB;
+
+      try {
+        await postService.create(POST_CREATE_STUB);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+        expect(e.message).toEqual(POST_ERROR.FAIL_CREATE);
+
+        expect(postRepositoryCreateSpy).toBeCalledTimes(1);
+        expect(postRepositoryCreateSpy).toBeCalledWith(rest);
+
+        expect(seriesServicePushPostSpy).toBeCalledTimes(0);
+        expect(tagServicePushPostIdInTagsSpy).toBeCalledTimes(0);
+      }
+    });
+  });
+
+  describe("게시글 수정", () => {
+    let postRepositoryGetByIdSpy: jest.SpyInstance;
+    let postRepositoryUpdateSpy: jest.SpyInstance;
+    let postRepositoryPushTagsSpy: jest.SpyInstance;
+    let postRepositoryPullTagsSpy: jest.SpyInstance;
+    let tagServicePushPostIdInTagsSpy: jest.SpyInstance;
+    let tagServicePullPostIdInTagsSpy: jest.SpyInstance;
+    let seriesServicePushPostIdSpy: jest.SpyInstance;
+    let seriesServicePullPostIdSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      postRepositoryGetByIdSpy = jest.spyOn(postRepository, "getById");
+      postRepositoryUpdateSpy = jest.spyOn(postRepository, "update");
+      postRepositoryPushTagsSpy = jest.spyOn(postRepository, "pushTags");
+      postRepositoryPullTagsSpy = jest.spyOn(postRepository, "pullTags");
+      tagServicePushPostIdInTagsSpy = jest.spyOn(tagService, "pushPostIdInTags");
+      tagServicePullPostIdInTagsSpy = jest.spyOn(tagService, "pullPostIdInTags");
+      seriesServicePushPostIdSpy = jest.spyOn(seriesService, "pushPostIdInSeries");
+      seriesServicePullPostIdSpy = jest.spyOn(seriesService, "pullPostIdInSeries");
+    });
+
+    it("성공", async () => {
+      const POST = { ...POST_STUB };
+
+      postRepositoryGetByIdSpy.mockResolvedValueOnce(POST);
+      postRepositoryGetByIdSpy.mockResolvedValueOnce(POST);
+      postRepositoryUpdateSpy.mockResolvedValueOnce(POST);
+      postRepositoryPushTagsSpy.mockResolvedValueOnce(undefined);
+      postRepositoryPullTagsSpy.mockResolvedValueOnce(undefined);
+      tagServicePushPostIdInTagsSpy.mockResolvedValueOnce([TAG_STUB]);
+      tagServicePullPostIdInTagsSpy.mockResolvedValueOnce([TAG_STUB]);
+      seriesServicePushPostIdSpy.mockResolvedValueOnce(SERIES_STUB);
+      seriesServicePullPostIdSpy.mockResolvedValueOnce(undefined);
+
+      const postId = POST._id;
+      const { deleteTags, addTags, ...rest } = POST_UPDATE_STUB;
+
+      const post = await postService.update({ ...POST_UPDATE_STUB });
+
+      expect(post).toEqual(POST);
+      expect(postRepositoryGetByIdSpy).toBeCalledTimes(2);
+      expect(postRepositoryGetByIdSpy).toBeCalledWith(postId);
+      expect(postRepositoryGetByIdSpy).toBeCalledWith(postId);
+
+      expect(postRepositoryUpdateSpy).toBeCalledTimes(1);
+      expect(postRepositoryUpdateSpy).toBeCalledWith({ ...rest, series: SERIES_STUB });
+
+      expect(postRepositoryPushTagsSpy).toBeCalledTimes(1);
+      expect(postRepositoryPushTagsSpy).toBeCalledWith(postId, [TAG_STUB]);
+
+      expect(postRepositoryPullTagsSpy).toBeCalledTimes(1);
+      expect(postRepositoryPullTagsSpy).toBeCalledWith(postId, [TAG_STUB]);
+
+      expect(tagServicePushPostIdInTagsSpy).toBeCalledTimes(1);
+      expect(tagServicePushPostIdInTagsSpy).toBeCalledWith(addTags, postId);
+
+      expect(tagServicePullPostIdInTagsSpy).toBeCalledTimes(1);
+      expect(tagServicePullPostIdInTagsSpy).toBeCalledWith(deleteTags, postId);
+
+      expect(seriesServicePushPostIdSpy).toBeCalledTimes(1);
+      expect(seriesServicePushPostIdSpy).toBeCalledWith(POST_UPDATE_STUB.series, postId);
+
+      expect(seriesServicePullPostIdSpy).toBeCalledTimes(1);
+      expect(seriesServicePullPostIdSpy).toBeCalledWith(POST_STUB.series.name, postId);
+    });
+
+    it("실패 - 존재하지 않는 게시글", async () => {
+      postRepositoryGetByIdSpy.mockResolvedValueOnce(null);
+
+      const POST = { ...POST_STUB };
+
+      await expect(postService.update({ ...POST_UPDATE_STUB })).rejects.toThrowError();
+
+      expect(postRepositoryGetByIdSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetByIdSpy).toBeCalledWith(POST._id);
+      expect(postRepositoryUpdateSpy).toBeCalledTimes(0);
+      expect(postRepositoryPushTagsSpy).toBeCalledTimes(0);
+      expect(postRepositoryPullTagsSpy).toBeCalledTimes(0);
+      expect(tagServicePushPostIdInTagsSpy).toBeCalledTimes(0);
+      expect(tagServicePullPostIdInTagsSpy).toBeCalledTimes(0);
+      expect(seriesServicePushPostIdSpy).toBeCalledTimes(0);
+      expect(seriesServicePullPostIdSpy).toBeCalledTimes(0);
+    });
+
+    it("실패 - 업데이트시 에러 발생", async () => {
+      const POST = { ...POST_STUB };
+      const postId = POST._id;
+
+      POST.series = null;
+
+      const POST_UPDATE = { ...POST_UPDATE_STUB };
+      POST_UPDATE.series = null;
+
+      const { deleteTags: _, addTags: __, ...rest } = POST_UPDATE;
+
+      postRepositoryGetByIdSpy.mockResolvedValueOnce(POST);
+      postRepositoryUpdateSpy.mockRejectedValueOnce(new Error(POST_ERROR.FAIL_UPDATE));
+
+      try {
+        await postService.update(POST_UPDATE);
+      } catch (e) {
+        expect(e).toBeInstanceOf(BadRequestException);
+        expect(e.status).toEqual(400);
+        expect(e.message).toEqual(POST_ERROR.FAIL_UPDATE);
+
+        expect(postRepositoryGetByIdSpy).toBeCalledTimes(1);
+        expect(postRepositoryGetByIdSpy).toBeCalledWith(postId);
+
+        expect(postRepositoryUpdateSpy).toBeCalledTimes(1);
+        expect(postRepositoryUpdateSpy).toBeCalledWith(rest);
+
+        expect(postRepositoryPushTagsSpy).toBeCalledTimes(0);
+        expect(postRepositoryPullTagsSpy).toBeCalledTimes(0);
+        expect(tagServicePushPostIdInTagsSpy).toBeCalledTimes(0);
+        expect(tagServicePullPostIdInTagsSpy).toBeCalledTimes(0);
+        expect(seriesServicePushPostIdSpy).toBeCalledTimes(0);
+        expect(seriesServicePullPostIdSpy).toBeCalledTimes(0);
+      }
+    });
+  });
+
+  describe("게시글 삭제", () => {
+    let postRepositoryGetByIdSpy: jest.SpyInstance;
+    let postRepositoryDeleteSpy: jest.SpyInstance;
+    let seriesServicePullPostIdSpy: jest.SpyInstance;
+    let tagServicePullPostIdInTagsSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      postRepositoryGetByIdSpy = jest.spyOn(postRepository, "getById");
+      postRepositoryDeleteSpy = jest.spyOn(postRepository, "delete");
+      seriesServicePullPostIdSpy = jest.spyOn(seriesService, "pullPostIdInSeries");
+      tagServicePullPostIdInTagsSpy = jest.spyOn(tagService, "pullPostIdInTags");
+    });
+
+    it("성공", async () => {
+      const POST = { ...POST_STUB };
+
+      postRepositoryGetByIdSpy.mockResolvedValueOnce(POST);
+      postRepositoryDeleteSpy.mockResolvedValueOnce(undefined);
+      seriesServicePullPostIdSpy.mockResolvedValueOnce(undefined);
+      tagServicePullPostIdInTagsSpy.mockResolvedValueOnce(undefined);
+
+      const postId = POST._id;
+
+      await postService.delete(postId);
+
+      expect(postRepositoryGetByIdSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetByIdSpy).toBeCalledWith(postId);
+
+      expect(postRepositoryDeleteSpy).toBeCalledTimes(1);
+      expect(postRepositoryDeleteSpy).toBeCalledWith(postId);
+
+      expect(seriesServicePullPostIdSpy).toBeCalledTimes(1);
+      expect(seriesServicePullPostIdSpy).toBeCalledWith(POST.series.name, postId);
+
+      expect(tagServicePullPostIdInTagsSpy).toBeCalledTimes(1);
+      expect(tagServicePullPostIdInTagsSpy).toBeCalledWith(
+        POST.tags.map((tag) => tag.name),
+        postId,
+      );
+    });
+  });
+
+  describe("게시글에서 시리즈 제거", () => {
+    it("성공", async () => {
+      const postRepositoryDeleteSeriesSpy: jest.SpyInstance = jest.spyOn(
+        postRepository,
+        "deleteSeriesInPosts",
+      );
+
+      postRepositoryDeleteSeriesSpy.mockResolvedValueOnce(undefined);
+
+      const POST = { ...POST_STUB };
+      const seriesId = POST.series._id;
+
+      await postService.deleteSeriesInPosts(seriesId);
+
+      expect(postRepositoryDeleteSeriesSpy).toBeCalledTimes(1);
+      expect(postRepositoryDeleteSeriesSpy).toBeCalledWith(seriesId);
+    });
+  });
+
+  describe("게시글 좋아요", () => {
+    const POST = { ...POST_STUB };
+
+    it("증가", async () => {
+      const postRepositoryIncreaseLikeSpy: jest.SpyInstance = jest.spyOn(
+        postRepository,
+        "increaseToLikes",
+      );
+
+      postRepositoryIncreaseLikeSpy.mockResolvedValueOnce(undefined);
+
+      await postService.increaseToLikes(POST._id, "ip");
+
+      expect(postRepositoryIncreaseLikeSpy).toBeCalledTimes(1);
+      expect(postRepositoryIncreaseLikeSpy).toBeCalledWith(POST._id, "ip");
+    });
+
+    it("감소", async () => {
+      const postRepositoryDecreaseLikeSpy: jest.SpyInstance = jest.spyOn(
+        postRepository,
+        "decreaseToLikes",
+      );
+
+      postRepositoryDecreaseLikeSpy.mockResolvedValueOnce(undefined);
+
+      await postService.decreaseToLikes(POST._id, "ip");
+
+      expect(postRepositoryDecreaseLikeSpy).toBeCalledTimes(1);
+      expect(postRepositoryDecreaseLikeSpy).toBeCalledWith(POST._id, "ip");
+    });
+  });
+
+  describe("게시글 조회수", () => {
+    const POST = { ...POST_STUB };
+
+    it("증가", async () => {
+      const postRepositoryIncreaseViewsSpy: jest.SpyInstance = jest.spyOn(
+        postRepository,
+        "increaseToViews",
+      );
+
+      postRepositoryIncreaseViewsSpy.mockResolvedValueOnce(undefined);
+
+      await postService.increaseToViews(POST._id, "ip");
+
+      expect(postRepositoryIncreaseViewsSpy).toBeCalledTimes(1);
+      expect(postRepositoryIncreaseViewsSpy).toBeCalledWith(POST._id, "ip");
+    });
+  });
+
+  describe("게시글 전체 조회", () => {
+    const POSTS = [POST_STUB];
+
+    let postRepositoryGetAllSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      postRepositoryGetAllSpy = jest.spyOn(postRepository, "getAll");
+      postRepositoryGetAllSpy.mockResolvedValueOnce(POSTS);
+    });
+
+    it("성공", async () => {
+      const posts = await postService.getAll({});
+
+      expect(posts).toEqual(POSTS);
+      expect(postRepositoryGetAllSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetAllSpy).toBeCalledWith({}, 10, 0);
+    });
+
+    it("성공 - 텍스트", async () => {
+      const dto = {
+        text: "text",
+      };
+      const options = filterQueryByPosts(dto);
+
+      const posts = await postService.getAll(dto);
+
+      expect(posts).toEqual(POSTS);
+      expect(postRepositoryGetAllSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetAllSpy).toBeCalledWith(options, 10, 0);
+    });
+
+    it("성공 - 시리즈/태그", async () => {
+      const dto = {
+        series: POST_STUB.series.name,
+        tag: TAG_STUB.name,
+      };
+
+      const options = filterQueryByPosts(dto);
+
+      const posts = await postService.getAll(dto);
+
+      expect(posts).toEqual(POSTS);
+      expect(postRepositoryGetAllSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetAllSpy).toBeCalledWith(options, 10, 0);
+    });
+
+    it("성공 - 텍스트/시리즈/태그/오프셋/리미트", async () => {
+      const dto = {
+        text: "text",
+        series: POST_STUB.series.name,
+        tag: TAG_STUB.name,
+        offset: 10,
+        limit: 10,
+      };
+
+      const options = filterQueryByPosts(dto);
+
+      const posts = await postService.getAll(dto);
+
+      expect(posts).toEqual(POSTS);
+      expect(postRepositoryGetAllSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetAllSpy).toBeCalledWith(options, dto.limit, dto.offset);
+    });
+  });
+
+  describe("게시글 조회", () => {
+    const POST = { ...POST_STUB };
+
+    it("성공 - 숫자 id로 조회", async () => {
+      const postRepositoryGetByNumIdSpy: jest.SpyInstance = jest.spyOn(
+        postRepository,
+        "getByNumId",
+      );
+      postRepositoryGetByNumIdSpy.mockResolvedValueOnce(POST);
+
+      const post = await postService.getByNumId(POST.nid);
+
+      expect(post).toEqual(POST);
+      expect(postRepositoryGetByNumIdSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetByNumIdSpy).toBeCalledWith(POST.nid);
+    });
+
+    it("성공 - Object id로 조회", async () => {
+      const postRepositoryGetByIdSpy: jest.SpyInstance = jest.spyOn(postRepository, "getById");
+      postRepositoryGetByIdSpy.mockResolvedValueOnce(POST);
+
+      const post = await postService.getById(POST._id);
+
+      expect(post).toEqual(POST);
+      expect(postRepositoryGetByIdSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetByIdSpy).toBeCalledWith(POST._id);
+    });
+
+    it("성공 - 특정 게시글을 기준으로 이전/다음 게시글 조회", async () => {
+      const postRepositoryGetSiblingSpy: jest.SpyInstance = jest.spyOn(
+        postRepository,
+        "getSibling",
+      );
+      postRepositoryGetSiblingSpy.mockResolvedValueOnce([POST, POST]);
+
+      const post = await postService.getSibling(POST.nid);
+
+      expect(post).toEqual([POST, POST]);
+      expect(postRepositoryGetSiblingSpy).toBeCalledTimes(1);
+      expect(postRepositoryGetSiblingSpy).toBeCalledWith(POST.nid);
+    });
+  });
+});

--- a/test/routes/series/series.service.spec.ts
+++ b/test/routes/series/series.service.spec.ts
@@ -119,7 +119,7 @@ describe("SeriesService", () => {
 
     beforeEach(() => {
       repositoryFindOrCreateSpy = jest.spyOn(repository, "findOrCreate");
-      repositoryPushPostId = jest.spyOn(repository, "pushPostId");
+      repositoryPushPostId = jest.spyOn(repository, "pushPostIdInSeries");
     });
 
     it("성공", async () => {
@@ -130,7 +130,7 @@ describe("SeriesService", () => {
       const seriesName = SERIES_STUB.name;
       const postId = SERIES_STUB.posts[0]._id;
 
-      const series = await service.pushPostId(seriesName, postId);
+      const series = await service.pushPostIdInSeries(seriesName, postId);
 
       expect(series).toEqual(SERIES_STUB);
       expect(repositoryPushPostId).toBeCalledTimes(1);
@@ -146,7 +146,7 @@ describe("SeriesService", () => {
 
     beforeEach(() => {
       repositoryGetByNameSpy = jest.spyOn(repository, "getByName");
-      repositoryPullPostIdSpy = jest.spyOn(repository, "pullPostId");
+      repositoryPullPostIdSpy = jest.spyOn(repository, "pullPostIdInSeries");
     });
 
     it("성공", async () => {
@@ -157,7 +157,7 @@ describe("SeriesService", () => {
       const seriesName = SERIES_STUB.name;
       const postId = SERIES_STUB.posts[0]._id;
 
-      await service.pullPostId(seriesName, postId);
+      await service.pullPostIdInSeries(seriesName, postId);
 
       expect(repositoryPullPostIdSpy).toBeCalledTimes(1);
       expect(repositoryPullPostIdSpy).toBeCalledWith(seriesId, postId);

--- a/test/routes/series/series.service.spec.ts
+++ b/test/routes/series/series.service.spec.ts
@@ -8,22 +8,26 @@ import {
   SERIES_UPDATE_INPUT_STUB,
 } from "test/utils/stub/series";
 
+import { PostService } from "@/routes/post/post.service";
 import { SeriesRepository } from "@/routes/series/series.repository";
 import { SeriesService } from "@/routes/series/series.service";
 import { SERIES_ERROR } from "@/utils/constants";
 
+jest.mock("@/routes/post/post.service");
 jest.mock("@/routes/series/series.repository");
 
 describe("SeriesService", () => {
   let service: SeriesService;
+  let postService: PostService;
   let repository: SeriesRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SeriesService, SeriesRepository],
+      providers: [SeriesService, PostService, SeriesRepository],
     }).compile();
 
     service = module.get<SeriesService>(SeriesService);
+    postService = module.get<PostService>(PostService);
     repository = module.get<SeriesRepository>(SeriesRepository);
 
     jest.clearAllMocks();
@@ -167,15 +171,18 @@ describe("SeriesService", () => {
   });
 
   describe("시리즈 삭제", () => {
+    let postServiceDeleteSeriesSpy: jest.SpyInstance;
     let repositoryDeleteSpy: jest.SpyInstance;
     let repositoryGetByIdSpy: jest.SpyInstance;
 
     beforeEach(() => {
+      postServiceDeleteSeriesSpy = jest.spyOn(postService, "deleteSeries");
       repositoryDeleteSpy = jest.spyOn(repository, "delete");
       repositoryGetByIdSpy = jest.spyOn(repository, "getById");
     });
 
     it("성공", async () => {
+      postServiceDeleteSeriesSpy.mockResolvedValueOnce(undefined);
       repositoryGetByIdSpy.mockResolvedValueOnce(SERIES_STUB);
       repositoryDeleteSpy.mockResolvedValueOnce(SERIES_STUB);
 

--- a/test/routes/series/series.service.spec.ts
+++ b/test/routes/series/series.service.spec.ts
@@ -113,35 +113,56 @@ describe("SeriesService", () => {
     });
   });
 
-  describe("시리즈 수정", () => {
+  describe("시리즈 수정 - 게시글 추가", () => {
     let repositoryFindOrCreateSpy: jest.SpyInstance;
-    let repositoryUpdateToPushPostSpy: jest.SpyInstance;
-    let repositoryGetByIdSpy: jest.SpyInstance;
+    let repositoryPushPostId: jest.SpyInstance;
 
     beforeEach(() => {
       repositoryFindOrCreateSpy = jest.spyOn(repository, "findOrCreate");
-      repositoryUpdateToPushPostSpy = jest.spyOn(repository, "updateToPushPost");
-      repositoryGetByIdSpy = jest.spyOn(repository, "getById");
+      repositoryPushPostId = jest.spyOn(repository, "pushPostId");
     });
 
     it("성공", async () => {
       repositoryFindOrCreateSpy.mockResolvedValueOnce(SERIES_STUB);
-      repositoryGetByIdSpy.mockResolvedValueOnce(SERIES_STUB);
-      repositoryUpdateToPushPostSpy.mockResolvedValueOnce(SERIES_STUB);
+      repositoryPushPostId.mockResolvedValueOnce(undefined);
 
       const seriesId = SERIES_STUB._id;
       const seriesName = SERIES_STUB.name;
       const postId = SERIES_STUB.posts[0]._id;
 
-      const series = await service.updateToPushPost(seriesName, postId);
+      const series = await service.pushPostId(seriesName, postId);
 
       expect(series).toEqual(SERIES_STUB);
-      expect(repositoryGetByIdSpy).toBeCalledTimes(1);
-      expect(repositoryGetByIdSpy).toBeCalledWith(seriesId);
-      expect(repositoryUpdateToPushPostSpy).toBeCalledTimes(1);
-      expect(repositoryUpdateToPushPostSpy).toBeCalledWith(seriesId, postId);
+      expect(repositoryPushPostId).toBeCalledTimes(1);
+      expect(repositoryPushPostId).toBeCalledWith(seriesId, postId);
       expect(repositoryFindOrCreateSpy).toBeCalledTimes(1);
       expect(repositoryFindOrCreateSpy).toBeCalledWith(seriesName);
+    });
+  });
+
+  describe("시리즈 수정 - 게시글 제거", () => {
+    let repositoryGetByNameSpy: jest.SpyInstance;
+    let repositoryPullPostIdSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      repositoryGetByNameSpy = jest.spyOn(repository, "getByName");
+      repositoryPullPostIdSpy = jest.spyOn(repository, "pullPostId");
+    });
+
+    it("성공", async () => {
+      repositoryGetByNameSpy.mockResolvedValueOnce(SERIES_STUB);
+      repositoryPullPostIdSpy.mockResolvedValueOnce(undefined);
+
+      const seriesId = SERIES_STUB._id;
+      const seriesName = SERIES_STUB.name;
+      const postId = SERIES_STUB.posts[0]._id;
+
+      await service.pullPostId(seriesName, postId);
+
+      expect(repositoryPullPostIdSpy).toBeCalledTimes(1);
+      expect(repositoryPullPostIdSpy).toBeCalledWith(seriesId, postId);
+      expect(repositoryGetByNameSpy).toBeCalledTimes(1);
+      expect(repositoryGetByNameSpy).toBeCalledWith(seriesName);
     });
   });
 

--- a/test/routes/tag/tag.service.spec.ts
+++ b/test/routes/tag/tag.service.spec.ts
@@ -61,7 +61,7 @@ describe("TagService", () => {
       repositoryFindOrCreateSpy.mockResolvedValueOnce(TAG_STUB);
       repositoryAddPostIdInTagsSpy.mockResolvedValueOnce(TAG_STUB);
 
-      const tags = await service.pushPostIdInTagNames([TAG_STUB.name], TAG_STUB.posts[0]._id);
+      const tags = await service.pushPostIdInTags([TAG_STUB.name], TAG_STUB.posts[0]._id);
 
       expect(tags).toEqual([TAG_STUB]);
 
@@ -77,24 +77,24 @@ describe("TagService", () => {
 
   describe("태그에 게시글 삭제", () => {
     it("태그 이름 배열을 받아 해당 이름과 일치하는 태그를 찾아 게시글 아이디를 삭제한다", async () => {
-      const repositoryPullPostIdInTagNamesSpy: jest.SpyInstance = jest.spyOn(
+      const repositorypullPostIdInTagsSpy: jest.SpyInstance = jest.spyOn(
         repository,
-        "pullPostIdInTagNames",
+        "pullPostIdInTags",
       );
       const repositoryGetAllByTagNamesSpy: jest.SpyInstance = jest.spyOn(
         repository,
         "getAllByTagNames",
       );
-      repositoryPullPostIdInTagNamesSpy.mockResolvedValueOnce(true);
+      repositorypullPostIdInTagsSpy.mockResolvedValueOnce(true);
       repositoryGetAllByTagNamesSpy.mockResolvedValueOnce([TAG_STUB]);
 
-      const tags = await service.pullPostIdInTagNames([TAG_STUB.name], TAG_STUB.posts[0]._id);
+      const tags = await service.pullPostIdInTags([TAG_STUB.name], TAG_STUB.posts[0]._id);
 
       expect(tags).toEqual([TAG_STUB]);
 
-      expect(repositoryPullPostIdInTagNamesSpy).toHaveBeenCalled();
-      expect(repositoryPullPostIdInTagNamesSpy).toHaveBeenCalledTimes(1);
-      expect(repositoryPullPostIdInTagNamesSpy).toHaveBeenCalledWith(
+      expect(repositorypullPostIdInTagsSpy).toHaveBeenCalled();
+      expect(repositorypullPostIdInTagsSpy).toHaveBeenCalledTimes(1);
+      expect(repositorypullPostIdInTagsSpy).toHaveBeenCalledWith(
         [TAG_STUB.name],
         TAG_STUB.posts[0]._id,
       );

--- a/test/utils/stub/index.ts
+++ b/test/utils/stub/index.ts
@@ -2,3 +2,4 @@ export * from "./user";
 export * from "./auth";
 export * from "./tag";
 export * from "./series";
+export * from "./post";

--- a/test/utils/stub/post.ts
+++ b/test/utils/stub/post.ts
@@ -1,0 +1,31 @@
+import { SERIES_STUB } from "test/utils/stub/series";
+import { TAG_STUB } from "test/utils/stub/tag";
+
+const POST_CREATE_STUB = {
+  title: "title",
+  content: "content",
+  thumbnail: "thumbnail",
+  series: "series",
+  tags: ["tags"],
+};
+
+const POST_UPDATE_STUB = {
+  _id: "_id",
+  title: "title",
+  deleteTags: ["delete"],
+  addTags: ["add"],
+};
+
+const POST_STUB = {
+  _id: "_id",
+  title: "title",
+  content: "content",
+  thumbnail: "thumbnail",
+  series: SERIES_STUB,
+  tags: TAG_STUB,
+  likes: ["likes"],
+  views: ["views"],
+  nid: 1,
+};
+
+export { POST_CREATE_STUB, POST_UPDATE_STUB, POST_STUB };

--- a/test/utils/stub/post.ts
+++ b/test/utils/stub/post.ts
@@ -1,31 +1,34 @@
 import { SERIES_STUB } from "test/utils/stub/series";
 import { TAG_STUB } from "test/utils/stub/tag";
 
-const POST_CREATE_STUB = {
+const POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES = {
   title: "title",
   content: "content",
   thumbnail: "thumbnail",
-  series: "series",
+};
+
+const POST_CREATE_STUB = {
+  ...POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES,
+  series: SERIES_STUB.name,
   tags: ["tags"],
 };
 
 const POST_UPDATE_STUB = {
   _id: "_id",
-  title: "title",
+  ...POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES,
+  series: "change_series",
   deleteTags: ["delete"],
   addTags: ["add"],
 };
 
 const POST_STUB = {
   _id: "_id",
-  title: "title",
-  content: "content",
-  thumbnail: "thumbnail",
+  ...POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES,
   series: SERIES_STUB,
-  tags: TAG_STUB,
+  tags: [TAG_STUB],
   likes: ["likes"],
   views: ["views"],
   nid: 1,
 };
 
-export { POST_CREATE_STUB, POST_UPDATE_STUB, POST_STUB };
+export { POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES, POST_CREATE_STUB, POST_UPDATE_STUB, POST_STUB };


### PR DESCRIPTION

-  #20

## ✨ **구현 기능 명세**
- Post Service 테스트 코드 및 비즈니스 로직 생성합니다.
- 게시글 생성시 시리즈, 태그를 함께 생성합니다.
- MongoDB는 캐스캐이딩을 지원하지 않기 때문에 삭제, 변경시 참조하고 있는 collection을 직접 변경합니다.

## 🌄 **스크린샷**
<img width="471" alt="image" src="https://github.com/seoko97/SEOKO-server/assets/60173534/170bdf82-0bc1-4cf9-b50b-1c7ffa6f1cc3">
