### PR TITLE
Repository 중복 로직 제거 및 오직 변경에 따른 코드 수정

### DIFF
--- a/src/common/repository/base.repository.ts
+++ b/src/common/repository/base.repository.ts
@@ -5,7 +5,7 @@ import { SequenceRepository } from "@/common/sequence/sequence.repository";
 export class BaseRepository<Document extends MDocument, CreateDto = unknown, UpdateDto = unknown> {
   constructor(
     private readonly model: Model<Document>,
-    private readonly sequenceRepository?: SequenceRepository,
+    private readonly sequenceRepository: SequenceRepository,
   ) {}
 
   async create(data: CreateDto): Promise<Document> {

--- a/src/routes/post/dto/get-posts.dto.ts
+++ b/src/routes/post/dto/get-posts.dto.ts
@@ -7,7 +7,7 @@ export class GetPostsDto {
   series?: string;
 
   @IsOptionalCustom(IsNumber())
-  offset?: number;
+  skip?: number;
 
   @IsOptionalCustom(IsNumber())
   limit?: number;

--- a/src/routes/post/dto/update-post.dto.ts
+++ b/src/routes/post/dto/update-post.dto.ts
@@ -5,7 +5,7 @@ import { IsArray, IsString } from "class-validator";
 import { IsOptionalCustom } from "@/common/decorators/is-optional.decorator";
 import { Post } from "@/routes/post/post.schema";
 
-export class UpdatePostDto extends PickType(Post, ["_id", "title", "content", "thumbnail"]) {
+export class UpdatePostDto extends PickType(Post, ["title", "content", "thumbnail"]) {
   @IsOptionalCustom(IsString())
   series?: string;
 

--- a/src/routes/post/post.controller.ts
+++ b/src/routes/post/post.controller.ts
@@ -23,8 +23,8 @@ export class PostController {
   }
 
   @Put(":_id")
-  async update(@Body() updatePostDto: UpdatePostDto) {
-    const post = await this.postService.update(updatePostDto);
+  async update(@Param("_id") _id: string, @Body() updatePostDto: UpdatePostDto) {
+    const post = await this.postService.update(_id, updatePostDto);
 
     return post;
   }

--- a/src/routes/series/dto/update-series.dto.ts
+++ b/src/routes/series/dto/update-series.dto.ts
@@ -6,11 +6,6 @@ import { CreateSeriesDto } from "@/routes/series/dto/create-series.dto";
 
 export class UpdateSeriesDto extends PartialType(CreateSeriesDto) {}
 
-export class UpdateSeriesDtoWithId extends UpdateSeriesDto {
-  @IsString()
-  _id!: string;
-}
-
 export class UpdateSeriesToPushPostDto {
   @IsString()
   postId!: string;

--- a/src/routes/series/series.controller.ts
+++ b/src/routes/series/series.controller.ts
@@ -10,7 +10,7 @@ export class SeriesController {
 
   @Public()
   @Get()
-  async getSeries() {
+  async getAll() {
     const series = await this.seriesService.getAll();
 
     return series;
@@ -18,21 +18,21 @@ export class SeriesController {
 
   @Public()
   @Get(":nid")
-  async getSeriesByNumId(@Param("nid") nid: number) {
+  async getByNumId(@Param("nid") nid: number) {
     const series = await this.seriesService.getByNumId(nid);
 
     return series;
   }
 
   @Patch(":_id")
-  async updateSeries(@Param("_id") _id: string, @Body() updateSeriesDto: UpdateSeriesDto) {
+  async update(@Param("_id") _id: string, @Body() updateSeriesDto: UpdateSeriesDto) {
     const series = await this.seriesService.update(_id, updateSeriesDto);
 
     return series;
   }
 
   @Delete(":_id")
-  async deleteSeries(@Param("_id") _id: string) {
+  async delete(@Param("_id") _id: string) {
     await this.seriesService.delete(_id);
 
     return true;

--- a/src/routes/series/series.controller.ts
+++ b/src/routes/series/series.controller.ts
@@ -11,27 +11,30 @@ export class SeriesController {
   @Public()
   @Get()
   async getSeries() {
-    return await this.seriesService.getAll();
+    const series = await this.seriesService.getAll();
+
+    return series;
   }
 
   @Public()
-  @Get(":numId")
-  async getSeriesByNumId(@Param("numId") numId: string) {
-    return await this.seriesService.getByNumId(Number(numId));
+  @Get(":nid")
+  async getSeriesByNumId(@Param("nid") nid: number) {
+    const series = await this.seriesService.getByNumId(nid);
+
+    return series;
   }
 
   @Patch(":_id")
   async updateSeries(@Param("_id") _id: string, @Body() updateSeriesDto: UpdateSeriesDto) {
-    const input = {
-      ...updateSeriesDto,
-      _id,
-    };
+    const series = await this.seriesService.update(_id, updateSeriesDto);
 
-    return await this.seriesService.update(input);
+    return series;
   }
 
   @Delete(":_id")
   async deleteSeries(@Param("_id") _id: string) {
-    return await this.seriesService.delete(_id);
+    await this.seriesService.delete(_id);
+
+    return true;
   }
 }

--- a/src/routes/series/series.repository.ts
+++ b/src/routes/series/series.repository.ts
@@ -4,7 +4,7 @@ import { InjectModel } from "@nestjs/mongoose";
 import { BaseRepository } from "@/common/repository/base.repository";
 import { SequenceRepository } from "@/common/sequence/sequence.repository";
 import { Series, SeriesDocument, SeriesModel } from "@/routes/series/series.schema";
-import { SERIES_FIND_OPTIONS, SERIES_FIND_PROJECTION } from "@/utils/constants";
+import { SERIES_FIND_PROJECTION } from "@/utils/constants";
 
 @Injectable()
 export class SeriesRepository extends BaseRepository<SeriesDocument> {
@@ -36,7 +36,7 @@ export class SeriesRepository extends BaseRepository<SeriesDocument> {
   }
 
   async getAll() {
-    return this.seriesModel.find({}, SERIES_FIND_PROJECTION, SERIES_FIND_OPTIONS);
+    return this.seriesModel.find({}, { ...SERIES_FIND_PROJECTION, posts: 0 });
   }
 
   async getById(_id: string) {

--- a/src/routes/tag/tag.repository.ts
+++ b/src/routes/tag/tag.repository.ts
@@ -4,6 +4,7 @@ import { InjectModel } from "@nestjs/mongoose";
 import { BaseRepository } from "@/common/repository/base.repository";
 import { SequenceRepository } from "@/common/sequence/sequence.repository";
 import { Tag, TagDocument, TagModel } from "@/routes/tag/tag.schema";
+import { GET_TAGS_OPTIONS } from "@/utils/constants/tag";
 
 @Injectable()
 export class TagRepository extends BaseRepository<TagDocument> {
@@ -45,5 +46,9 @@ export class TagRepository extends BaseRepository<TagDocument> {
     if (tag) return tag;
 
     return super.create({ name });
+  }
+
+  async getAllToA() {
+    return this.tagModel.aggregate<TagDocument>(GET_TAGS_OPTIONS).exec();
   }
 }

--- a/src/routes/tag/tag.repository.ts
+++ b/src/routes/tag/tag.repository.ts
@@ -1,27 +1,29 @@
 import { Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 
+import { BaseRepository } from "@/common/repository/base.repository";
 import { SequenceRepository } from "@/common/sequence/sequence.repository";
 import { Tag, TagDocument, TagModel } from "@/routes/tag/tag.schema";
-import { GET_TAGS_OPTIONS } from "@/utils/constants/tag";
 
 @Injectable()
-export class TagRepository {
+export class TagRepository extends BaseRepository<TagDocument> {
   constructor(
     @InjectModel(Tag.name) private readonly tagModel: TagModel,
-    private readonly sequenceRepository: SequenceRepository,
-  ) {}
+    sequenceRepository: SequenceRepository,
+  ) {
+    super(tagModel, sequenceRepository);
+  }
 
   async addPostIdInTags(tags: TagDocument[], postId: string) {
     return await this.tagModel.updateMany(
-      { _id: { $in: tags.map((tag) => tag._id) } },
-      { $addToSet: { posts: postId } },
+      { posts: { $ne: postId }, _id: { $in: tags.map((tag) => tag._id) } },
+      { $push: { posts: postId } },
     );
   }
 
   async pullPostIdInTags(tagNames: string[], postId: string) {
     await this.tagModel
-      .updateMany({ name: { $in: tagNames } }, { $pull: { posts: postId } })
+      .updateMany({ name: { $in: tagNames }, posts: { $in: postId } }, { $pull: { posts: postId } })
       .exec();
 
     await this.deleteTagsByEmptyPosts();
@@ -42,20 +44,6 @@ export class TagRepository {
 
     if (tag) return tag;
 
-    const nid = await this.sequenceRepository.getNextSequence("tag");
-
-    return await this.tagModel.create({ name, nid });
-  }
-
-  async getByName(name: string) {
-    return this.tagModel.findOne({ name }).populate("posts");
-  }
-
-  async getAll() {
-    return await this.tagModel.aggregate<TagDocument>(GET_TAGS_OPTIONS).exec();
-  }
-
-  async getAllByTagNames(tagNames: string[]) {
-    return await this.tagModel.find({ name: { $in: tagNames } });
+    return super.create({ name });
   }
 }

--- a/src/routes/tag/tag.service.ts
+++ b/src/routes/tag/tag.service.ts
@@ -7,11 +7,15 @@ export class TagService {
   constructor(private readonly tagRepository: TagRepository) {}
 
   async getAll() {
-    return this.tagRepository.getAll();
+    return this.tagRepository.getAll(
+      { posts: { $exists: true, $ne: [] } },
+      { postCount: { $size: "$posts" } },
+      { sort: { postCount: -1 } },
+    );
   }
 
   async getByName(name: string) {
-    return this.tagRepository.getByName(name);
+    return this.tagRepository.getOne({ name }, {}, { populate: "posts" });
   }
 
   async pushPostIdInTags(tagNames: string[], postId: string) {
@@ -27,7 +31,7 @@ export class TagService {
   async pullPostIdInTags(tagNames: string[], postId: string) {
     await this.tagRepository.pullPostIdInTags(tagNames, postId);
 
-    return this.tagRepository.getAllByTagNames(tagNames);
+    return this.tagRepository.getAll({ name: { $in: tagNames } });
   }
 
   async pullPostIdByPostId(postId: string) {

--- a/src/routes/tag/tag.service.ts
+++ b/src/routes/tag/tag.service.ts
@@ -7,11 +7,7 @@ export class TagService {
   constructor(private readonly tagRepository: TagRepository) {}
 
   async getAll() {
-    return this.tagRepository.getAll(
-      { posts: { $exists: true, $ne: [] } },
-      { postCount: { $size: "$posts" } },
-      { sort: { postCount: -1 } },
-    );
+    return this.tagRepository.getAllToA();
   }
 
   async getByName(name: string) {

--- a/src/routes/user/user.module.ts
+++ b/src/routes/user/user.module.ts
@@ -1,13 +1,14 @@
 import { Module } from "@nestjs/common";
 import { MongooseModule } from "@nestjs/mongoose";
 
+import { SequenceModule } from "@/common/sequence/sequence.module";
 import { UserController } from "@/routes/user/user.controller";
 import { UserRepository } from "@/routes/user/user.repository";
 import { User, UserSchema } from "@/routes/user/user.schema";
 import { UserService } from "@/routes/user/user.service";
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: User.name, schema: UserSchema }])],
+  imports: [MongooseModule.forFeature([{ name: User.name, schema: UserSchema }]), SequenceModule],
   controllers: [UserController],
   exports: [UserService],
   providers: [UserController, UserService, UserRepository],

--- a/src/routes/user/user.service.ts
+++ b/src/routes/user/user.service.ts
@@ -9,7 +9,8 @@ export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
   async create(createUserDto: CreateUserDTO) {
-    const user = await this.userRepository.getByUserId(createUserDto.userId);
+    const userId = createUserDto.userId;
+    const user = await this.userRepository.getOne({ userId });
 
     if (user) {
       throw new BadRequestException(USER_ERROR.ALREADY_EXISTS);
@@ -19,14 +20,14 @@ export class UserService {
   }
 
   async getByUserId(userId: string) {
-    return this.userRepository.getByUserId(userId);
+    return this.userRepository.getOne({ userId });
   }
 
   async getById(_id: string) {
-    return this.userRepository.getById(_id);
+    return this.userRepository.getById(_id, { password: 0 });
   }
 
   async updateRefreshToken(_id: string, refreshToken: string = null) {
-    return this.userRepository.updateRefreshToken(_id, refreshToken);
+    return this.userRepository.update(_id, { refreshToken });
   }
 }

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,0 +1,10 @@
+import { Series } from "@/routes/series/series.schema";
+
+interface IUpdatePostArgs {
+  title?: string;
+  content?: string;
+  thumbnail?: string;
+  series?: Series | null;
+}
+
+export { IUpdatePostArgs };

--- a/src/utils/constants/post.ts
+++ b/src/utils/constants/post.ts
@@ -5,4 +5,18 @@ const POST_ERROR = {
   ALREADY_LIKED: "이미 좋아요를 누른 게시글입니다.",
 };
 
-export { POST_ERROR };
+const POST_FIND_PROJECTION = {
+  _id: 1,
+  title: 1,
+  content: 1,
+  thumbnail: 1,
+  nid: 1,
+  createdAt: 1,
+  updatedAt: 1,
+  tags: 1,
+  series: 1,
+  likeCount: { $size: "$likes" },
+  viewCount: { $size: "$views" },
+};
+
+export { POST_ERROR, POST_FIND_PROJECTION };

--- a/src/utils/constants/series.ts
+++ b/src/utils/constants/series.ts
@@ -14,7 +14,6 @@ const SERIES_FIND_PROJECTION = {
 };
 
 const SERIES_FIND_OPTIONS = {
-  sort: { postCount: -1 },
   populate: "posts",
 };
 

--- a/src/utils/constants/series.ts
+++ b/src/utils/constants/series.ts
@@ -4,4 +4,18 @@ const SERIES_ERROR = {
   ALREADY_EXISTS: "이미 존재하는 시리즈입니다.",
 };
 
-export { SERIES_ERROR };
+const SERIES_FIND_PROJECTION = {
+  _id: 1,
+  nid: 1,
+  name: 1,
+  thumbnail: 1,
+  posts: 1,
+  postCount: { $size: "$posts" },
+};
+
+const SERIES_FIND_OPTIONS = {
+  sort: { postCount: -1 },
+  populate: "posts",
+};
+
+export { SERIES_ERROR, SERIES_FIND_PROJECTION, SERIES_FIND_OPTIONS };

--- a/src/utils/constants/tag.ts
+++ b/src/utils/constants/tag.ts
@@ -1,6 +1,14 @@
+import { PipelineStage } from "mongoose";
+
 const TAG_ERROR = {
   NOT_FOUND: "존재하지 않는 태그입니다.",
   ALREADY_EXIST: "이미 존재하는 태그입니다.",
 };
 
-export { TAG_ERROR };
+const GET_TAGS_OPTIONS: PipelineStage[] = [
+  { $lookup: { from: "posts", localField: "posts", foreignField: "_id", as: "posts" } },
+  { $project: { _id: 1, name: 1, createdAt: 1, updatedAt: 1, postCount: { $size: "$posts" } } },
+  { $sort: { postCount: -1 } },
+];
+
+export { TAG_ERROR, GET_TAGS_OPTIONS };

--- a/src/utils/constants/tag.ts
+++ b/src/utils/constants/tag.ts
@@ -1,33 +1,6 @@
-import { PipelineStage } from "mongoose";
-
 const TAG_ERROR = {
   NOT_FOUND: "존재하지 않는 태그입니다.",
   ALREADY_EXIST: "이미 존재하는 태그입니다.",
 };
 
-const GET_TAGS_OPTIONS: PipelineStage[] = [
-  {
-    $lookup: {
-      from: "posts",
-      localField: "posts",
-      foreignField: "_id",
-      as: "posts",
-    },
-  },
-  {
-    $project: {
-      _id: 1,
-      name: 1,
-      createdAt: 1,
-      updatedAt: 1,
-      postCount: { $size: "$posts" },
-    },
-  },
-  {
-    $sort: {
-      postCount: -1,
-    },
-  },
-];
-
-export { TAG_ERROR, GET_TAGS_OPTIONS };
+export { TAG_ERROR };

--- a/test/routes/post/post.controller.spec.ts
+++ b/test/routes/post/post.controller.spec.ts
@@ -46,11 +46,12 @@ describe("PostController", () => {
       const serviceUpdateSpy: jest.SpyInstance = jest.spyOn(service, "update");
       serviceUpdateSpy.mockResolvedValueOnce(POST_STUB);
 
-      const result = await controller.update(POST_UPDATE_STUB);
+      const postId = POST_STUB._id;
+      const result = await controller.update(postId, POST_UPDATE_STUB);
 
       expect(result).toEqual(POST_STUB);
       expect(serviceUpdateSpy).toBeCalledTimes(1);
-      expect(serviceUpdateSpy).toBeCalledWith(POST_UPDATE_STUB);
+      expect(serviceUpdateSpy).toBeCalledWith(postId, POST_UPDATE_STUB);
     });
   });
 

--- a/test/routes/series/series.controller.spec.ts
+++ b/test/routes/series/series.controller.spec.ts
@@ -39,7 +39,7 @@ describe("SeriesController", () => {
     it("성공", async () => {
       serviceGetAllSpy.mockResolvedValueOnce([SERIES_STUB]);
 
-      const series = await controller.getSeries();
+      const series = await controller.getAll();
 
       expect(series).toEqual([SERIES_STUB]);
       expect(serviceGetAllSpy).toHaveBeenCalled();
@@ -57,7 +57,7 @@ describe("SeriesController", () => {
     it("성공", async () => {
       serviceGetByNumIdSpy.mockResolvedValueOnce(SERIES_STUB);
 
-      const series = await controller.getSeriesByNumId("1");
+      const series = await controller.getByNumId(SERIES_STUB.nid);
 
       expect(series).toEqual(SERIES_STUB);
       expect(serviceGetByNumIdSpy).toHaveBeenCalled();
@@ -68,7 +68,7 @@ describe("SeriesController", () => {
       serviceGetByNumIdSpy.mockRejectedValueOnce(new NotFoundException(SERIES_ERROR.NOT_FOUND));
 
       try {
-        await controller.getSeriesByNumId("1");
+        await controller.getByNumId(SERIES_STUB.nid);
       } catch (e) {
         expect(e.status).toBe(404);
         expect(e.message).toBe(SERIES_ERROR.NOT_FOUND);
@@ -90,7 +90,7 @@ describe("SeriesController", () => {
     it("성공", async () => {
       serviceUpdateSpy.mockResolvedValueOnce(SERIES_STUB);
 
-      const series = await controller.updateSeries("1", SERIES_STUB);
+      const series = await controller.update("1", SERIES_STUB);
 
       expect(series).toEqual(SERIES_STUB);
       expect(serviceUpdateSpy).toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe("SeriesController", () => {
       serviceUpdateSpy.mockRejectedValueOnce(new BadRequestException(SERIES_ERROR.NOT_FOUND));
 
       try {
-        await controller.updateSeries("1", SERIES_STUB);
+        await controller.update("1", SERIES_STUB);
       } catch (e) {
         expect(e.status).toBe(400);
         expect(e.message).toBe(SERIES_ERROR.NOT_FOUND);
@@ -121,11 +121,11 @@ describe("SeriesController", () => {
     });
 
     it("성공", async () => {
-      serviceDeleteSpy.mockResolvedValueOnce(SERIES_STUB);
+      serviceDeleteSpy.mockResolvedValueOnce(undefined);
 
-      const series = await controller.deleteSeries("1");
+      const series = await controller.delete("1");
 
-      expect(series).toEqual(SERIES_STUB);
+      expect(series).toEqual(true);
       expect(serviceDeleteSpy).toHaveBeenCalled();
       expect(serviceDeleteSpy).toHaveBeenCalledTimes(1);
     });
@@ -134,7 +134,7 @@ describe("SeriesController", () => {
       serviceDeleteSpy.mockRejectedValueOnce(new BadRequestException(SERIES_ERROR.NOT_FOUND));
 
       try {
-        await controller.deleteSeries("1");
+        await controller.delete("1");
       } catch (e) {
         expect(e.status).toBe(400);
         expect(e.message).toBe(SERIES_ERROR.NOT_FOUND);

--- a/test/routes/tag/tag.service.spec.ts
+++ b/test/routes/tag/tag.service.spec.ts
@@ -36,18 +36,27 @@ describe("TagService", () => {
       expect(tags).toEqual([TAG_STUB]);
       expect(repositoryGetAllSpy).toHaveBeenCalled();
       expect(repositoryGetAllSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryGetAllSpy).toHaveBeenCalledWith(
+        { posts: { $exists: true, $ne: [] } },
+        { postCount: { $size: "$posts" } },
+        { sort: { postCount: -1 } },
+      );
     });
 
     it("태그 이름으로 조회", async () => {
-      const repositoryGetByNameSpy: jest.SpyInstance = jest.spyOn(repository, "getByName");
-      repositoryGetByNameSpy.mockResolvedValueOnce(TAG_STUB);
+      const repositoryGetOneSpy: jest.SpyInstance = jest.spyOn(repository, "getOne");
+      repositoryGetOneSpy.mockResolvedValueOnce(TAG_STUB);
 
       const tag = await service.getByName(TAG_STUB.name);
 
       expect(tag).toEqual(TAG_STUB);
-      expect(repositoryGetByNameSpy).toHaveBeenCalled();
-      expect(repositoryGetByNameSpy).toHaveBeenCalledTimes(1);
-      expect(repositoryGetByNameSpy).toHaveBeenCalledWith(TAG_STUB.name);
+      expect(repositoryGetOneSpy).toHaveBeenCalled();
+      expect(repositoryGetOneSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryGetOneSpy).toHaveBeenCalledWith(
+        { name: TAG_STUB.name },
+        {},
+        { populate: "posts" },
+      );
     });
   });
 
@@ -77,31 +86,29 @@ describe("TagService", () => {
 
   describe("태그에 게시글 삭제", () => {
     it("태그 이름 배열을 받아 해당 이름과 일치하는 태그를 찾아 게시글 아이디를 삭제한다", async () => {
-      const repositorypullPostIdInTagsSpy: jest.SpyInstance = jest.spyOn(
+      const repositoryPullPostIdInTagsSpy: jest.SpyInstance = jest.spyOn(
         repository,
         "pullPostIdInTags",
       );
-      const repositoryGetAllByTagNamesSpy: jest.SpyInstance = jest.spyOn(
-        repository,
-        "getAllByTagNames",
-      );
-      repositorypullPostIdInTagsSpy.mockResolvedValueOnce(true);
-      repositoryGetAllByTagNamesSpy.mockResolvedValueOnce([TAG_STUB]);
+      const repositoryGetAllSpy: jest.SpyInstance = jest.spyOn(repository, "getAll");
+
+      repositoryPullPostIdInTagsSpy.mockResolvedValueOnce(true);
+      repositoryGetAllSpy.mockResolvedValueOnce([TAG_STUB]);
 
       const tags = await service.pullPostIdInTags([TAG_STUB.name], TAG_STUB.posts[0]._id);
 
       expect(tags).toEqual([TAG_STUB]);
 
-      expect(repositorypullPostIdInTagsSpy).toHaveBeenCalled();
-      expect(repositorypullPostIdInTagsSpy).toHaveBeenCalledTimes(1);
-      expect(repositorypullPostIdInTagsSpy).toHaveBeenCalledWith(
+      expect(repositoryPullPostIdInTagsSpy).toHaveBeenCalled();
+      expect(repositoryPullPostIdInTagsSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryPullPostIdInTagsSpy).toHaveBeenCalledWith(
         [TAG_STUB.name],
         TAG_STUB.posts[0]._id,
       );
 
-      expect(repositoryGetAllByTagNamesSpy).toHaveBeenCalled();
-      expect(repositoryGetAllByTagNamesSpy).toHaveBeenCalledTimes(1);
-      expect(repositoryGetAllByTagNamesSpy).toHaveBeenCalledWith([TAG_STUB.name]);
+      expect(repositoryGetAllSpy).toHaveBeenCalled();
+      expect(repositoryGetAllSpy).toHaveBeenCalledTimes(1);
+      expect(repositoryGetAllSpy).toHaveBeenCalledWith({ name: { $in: [TAG_STUB.name] } });
     });
 
     it("게시글 아이디를 받아 해당 게시글을 가지고 있는 태그를 찾아 게시글 아이디를 삭제한다", async () => {

--- a/test/routes/tag/tag.service.spec.ts
+++ b/test/routes/tag/tag.service.spec.ts
@@ -28,7 +28,7 @@ describe("TagService", () => {
 
   describe("태그 조회", () => {
     it("태그 전체 조회", async () => {
-      const repositoryGetAllSpy: jest.SpyInstance = jest.spyOn(repository, "getAll");
+      const repositoryGetAllSpy: jest.SpyInstance = jest.spyOn(repository, "getAllToA");
       repositoryGetAllSpy.mockResolvedValueOnce([TAG_STUB]);
 
       const tags = await service.getAll();
@@ -36,11 +36,7 @@ describe("TagService", () => {
       expect(tags).toEqual([TAG_STUB]);
       expect(repositoryGetAllSpy).toHaveBeenCalled();
       expect(repositoryGetAllSpy).toHaveBeenCalledTimes(1);
-      expect(repositoryGetAllSpy).toHaveBeenCalledWith(
-        { posts: { $exists: true, $ne: [] } },
-        { postCount: { $size: "$posts" } },
-        { sort: { postCount: -1 } },
-      );
+      expect(repositoryGetAllSpy).toHaveBeenCalledWith();
     });
 
     it("태그 이름으로 조회", async () => {

--- a/test/routes/user/user.service.spec.ts
+++ b/test/routes/user/user.service.spec.ts
@@ -1,7 +1,6 @@
 import { BadRequestException } from "@nestjs/common";
 import { TestingModule } from "@nestjs/testing";
 
-import { MockUserRepository } from "test/utils/mock/user";
 import createTestingModule from "test/utils/mongo/createTestModule";
 import { USER_INPUT_STUB, USER_STUB, USER_STUB_NON_PASSWORD } from "test/utils/stub";
 
@@ -9,19 +8,15 @@ import { UserRepository } from "@/routes/user/user.repository";
 import { UserService } from "@/routes/user/user.service";
 import { USER_ERROR } from "@/utils/constants";
 
+jest.mock("@/routes/user/user.repository");
+
 describe("UserService", () => {
   let service: UserService;
   let repository: UserRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await createTestingModule({
-      providers: [
-        UserService,
-        {
-          provide: UserRepository,
-          useClass: MockUserRepository,
-        },
-      ],
+      providers: [UserService, UserRepository],
     });
 
     service = module.get<UserService>(UserService);
@@ -31,23 +26,32 @@ describe("UserService", () => {
   });
 
   describe("유저 생성", () => {
-    let repositoryGetByUserIdSpy: jest.SpyInstance;
+    let repositoryGetOneSpy: jest.SpyInstance;
+    let repositoryCreateSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      repositoryGetByUserIdSpy = jest.spyOn(repository, "getByUserId");
+      repositoryGetOneSpy = jest.spyOn(repository, "getOne");
+      repositoryCreateSpy = jest.spyOn(repository, "create");
     });
 
     it("성공", async () => {
-      repositoryGetByUserIdSpy.mockImplementationOnce(() => null);
+      repositoryGetOneSpy.mockResolvedValueOnce(null);
+      repositoryCreateSpy.mockResolvedValueOnce(USER_STUB_NON_PASSWORD);
 
       const user = await service.create(USER_INPUT_STUB);
 
-      expect(user).toEqual(USER_STUB);
+      expect(user).toEqual(USER_STUB_NON_PASSWORD);
+
+      expect(repositoryGetOneSpy).toBeCalledTimes(1);
+      expect(repositoryGetOneSpy).toBeCalledWith({ userId: USER_INPUT_STUB.userId });
+
+      expect(repositoryCreateSpy).toBeCalledTimes(1);
+      expect(repositoryCreateSpy).toBeCalledWith(USER_INPUT_STUB);
     });
 
     describe("실패", () => {
       it("이미 존재하는 유저", async () => {
-        repositoryGetByUserIdSpy.mockResolvedValueOnce(USER_STUB);
+        repositoryGetOneSpy.mockResolvedValueOnce(USER_STUB);
 
         try {
           await service.create(USER_STUB);
@@ -56,28 +60,40 @@ describe("UserService", () => {
           expect(e.message).toBe(USER_ERROR.ALREADY_EXISTS);
           expect(e).toBeInstanceOf(BadRequestException);
 
-          expect(repositoryGetByUserIdSpy).toBeCalledTimes(1);
-          expect(repositoryGetByUserIdSpy).toBeCalledWith(USER_INPUT_STUB.userId);
+          expect(repositoryGetOneSpy).toBeCalledTimes(1);
+          expect(repositoryGetOneSpy).toBeCalledWith({ userId: USER_INPUT_STUB.userId });
+
+          expect(repositoryCreateSpy).not.toBeCalled();
         }
       });
     });
   });
 
   describe("유저 조회", () => {
-    // 유저 아이디로 조회시애는 패스워드가 존재함
     it("유저 아이디로 조회", async () => {
+      const repositoryGetOneSpy = jest.spyOn(repository, "getOne");
+      repositoryGetOneSpy.mockResolvedValueOnce(USER_STUB);
+
       const user = await service.getByUserId(USER_STUB.userId);
 
       expect(user).toEqual(USER_STUB);
       expect(user.password).toBeDefined();
+
+      expect(repositoryGetOneSpy).toBeCalledTimes(1);
+      expect(repositoryGetOneSpy).toBeCalledWith({ userId: USER_STUB.userId });
     });
 
-    // unique id로 조회시 패스워드가 존재하지 않음
     it("unique id로 조회", async () => {
+      const repositoryGetByIdSpy = jest.spyOn(repository, "getById");
+      repositoryGetByIdSpy.mockResolvedValueOnce(USER_STUB_NON_PASSWORD);
+
       const user = await service.getById(USER_STUB._id);
 
       expect(user).toEqual(USER_STUB_NON_PASSWORD);
       expect(user.password).toBeUndefined();
+
+      expect(repositoryGetByIdSpy).toBeCalledTimes(1);
+      expect(repositoryGetByIdSpy).toBeCalledWith(USER_STUB._id, { password: 0 });
     });
   });
 });

--- a/test/utils/stub/post.ts
+++ b/test/utils/stub/post.ts
@@ -18,7 +18,7 @@ const POST_CREATE_STUB: CreatePostDto = {
 };
 
 const GET_POSTS_DTO_STUB: GetPostsDto = {
-  offset: 0,
+  skip: 0,
   limit: 10,
   series: "series",
   tag: "tag",
@@ -26,7 +26,6 @@ const GET_POSTS_DTO_STUB: GetPostsDto = {
 };
 
 const POST_UPDATE_STUB: UpdatePostDto = {
-  _id: "_id",
   ...POST_CREATE_STUB_WITHOUT_TAGS_AND_SERIES,
   series: "change_series",
   deleteTags: ["delete"],

--- a/test/utils/stub/series.ts
+++ b/test/utils/stub/series.ts
@@ -4,7 +4,6 @@ const SERIES_CREATE_INPUT_STUB = {
 };
 
 const SERIES_UPDATE_INPUT_STUB = {
-  _id: "id",
   ...SERIES_CREATE_INPUT_STUB,
 };
 
@@ -15,6 +14,7 @@ const SERIES_STUB_WITHOUT_POSTS = {
 
 const SERIES_STUB = {
   ...SERIES_STUB_WITHOUT_POSTS,
+  _id: "id",
   posts: [{ _id: "id" }],
   nid: 1,
 };

--- a/test/utils/stub/user.ts
+++ b/test/utils/stub/user.ts
@@ -1,5 +1,7 @@
 import { TOKEN_STUB } from "test/utils/stub/auth";
 
+import { UserDocument } from "@/routes/user/user.schema";
+
 const TOKEN_USER_STUB = {
   _id: "id",
 };
@@ -15,12 +17,12 @@ const USER_STUB_NON_PASSWORD = {
   username: "test",
   refreshToken: TOKEN_STUB,
   nid: 1,
-};
+} as unknown as UserDocument;
 
 const USER_STUB = {
   ...USER_STUB_NON_PASSWORD,
   password: "test",
-};
+} as unknown as UserDocument;
 
 const USER_INPUT_STUB = {
   ...USER_ID_PASSWORD_STUB,


### PR DESCRIPTION

-  Closes #32

## ✨ **구현 기능 명세**
- Base Repository를 정의하여 중복되는 로직을 상속받을 수 있도록 변경합니다.
- 정의된 메서드가 변경됨에 따라 테스트 및 비즈니스 로직을 수정합니다.
